### PR TITLE
Retrieve divorce application fee from Fee Register

### DIFF
--- a/app/core/DestroySessionStep.js
+++ b/app/core/DestroySessionStep.js
@@ -14,4 +14,8 @@ module.exports = class DestroySessionStep extends Step {
   get nextStep() {
     return null;
   }
+
+  get middleware() {
+    return [];
+  }
 };

--- a/app/core/OptionStep.js
+++ b/app/core/OptionStep.js
@@ -35,4 +35,7 @@ module.exports = class OptionStep extends ValidationStep {
 
     return val;
   }
+  get middleware() {
+    return super.middleware;
+  }
 };

--- a/app/middleware/sessions.js
+++ b/app/middleware/sessions.js
@@ -22,6 +22,9 @@ const sessions = module.exports = { // eslint-disable-line no-multi-assign
   },
   redis: () => {
     const client = ioRedis.createClient(redisHost);
+    client.on('error', error => {
+      logger.error(error);
+    });
 
     client.on('connect', () => {
       logger.info({ message: 'Connected to Redis' });

--- a/app/middleware/updateApplicationFeeMiddleware.js
+++ b/app/middleware/updateApplicationFeeMiddleware.js
@@ -3,11 +3,19 @@ const feeRegisterService = require('app/services/feeRegisterService');
 const mockFeeReigsterService = require('app/services/mocks/feeRegisterService');
 const logger = require('@hmcts/nodejs-logging').getLogger(__filename);
 const ioRedis = require('ioredis');
+const ioRedisMock = require('app/services/mocks/ioRedis');
 
 const redisHost = CONF.services.redis.host;
 
 // redisClient is a let so it can be rewired in tests
-let redisClient = new ioRedis(redisHost); // eslint-disable-line prefer-const
+let redisClient = {};
+
+if (process.env.NODE_ENV === 'testing') {
+  redisClient = ioRedisMock();
+} else {
+  redisClient = new ioRedis(redisHost); // eslint-disable-line prefer-const
+}
+
 redisClient.on('error', error => {
   logger.error(error);
 });

--- a/app/middleware/updateApplicationFeeMiddleware.js
+++ b/app/middleware/updateApplicationFeeMiddleware.js
@@ -1,0 +1,46 @@
+const CONF = require('config');
+const feeRegisterService = require('app/services/feeRegisterService');
+const mockFeeReigsterService = require('app/services/mocks/feeRegisterService');
+const logger = require('@hmcts/nodejs-logging').getLogger(__filename);
+const ioRedis = require('ioredis');
+
+const redisHost = CONF.services.redis.host;
+// redisClient is a let so it can be rewired in tests
+let redisClient = new ioRedis(redisHost); // eslint-disable-line prefer-const
+
+const applicationFeeQueryParams = 'service=devorce&jurisdiction1=family&jurisdiction2=family%20court&channel=default&event=issue';
+
+const getFeeFromService = () => {
+  const service = CONF.deployment_env === 'dev' ? mockFeeReigsterService : feeRegisterService;
+  const options = { queryParameters: applicationFeeQueryParams };
+
+  return service.get(options)
+    .then(response => {
+      // set fee returned from fee register to global CONF
+      CONF.commonProps.applicationFee = response;
+      return redisClient.set('commonProps.applicationFee', JSON.stringify(response));
+    })
+    .then(() => {
+      return redisClient.expire('commonProps.applicationFee', CONF.services.feeRegister.TTL);
+    });
+};
+
+const updateApplicationFeeMiddleware = (req, res, next) => {
+  redisClient.get('commonProps.applicationFee')
+    .then(response => {
+      if (response) {
+        CONF.commonProps.applicationFee = JSON.parse(response);
+        return true;
+      }
+      return getFeeFromService(next);
+    })
+    .then(() => {
+      next();
+    })
+    .catch(error => {
+      logger.error(`Error retrieving fee from Fee registry: ${error}`);
+      res.redirect('/generic-error');
+    });
+};
+
+module.exports = { updateApplicationFeeMiddleware };

--- a/app/middleware/updateApplicationFeeMiddleware.js
+++ b/app/middleware/updateApplicationFeeMiddleware.js
@@ -5,8 +5,12 @@ const logger = require('@hmcts/nodejs-logging').getLogger(__filename);
 const ioRedis = require('ioredis');
 
 const redisHost = CONF.services.redis.host;
+
 // redisClient is a let so it can be rewired in tests
 let redisClient = new ioRedis(redisHost); // eslint-disable-line prefer-const
+redisClient.on('error', error => {
+  logger.error(error);
+});
 
 const applicationFeeQueryParams = 'service=devorce&jurisdiction1=family&jurisdiction2=family%20court&channel=default&event=issue';
 

--- a/app/middleware/updateApplicationFeeMiddleware.test.js
+++ b/app/middleware/updateApplicationFeeMiddleware.test.js
@@ -32,7 +32,7 @@ describe(modulePath, () => {
     });
     it('gets application fee redis if available', done => {
       ioRedisClient.get = sinon.stub()
-        .resolves(mockFeeReigsterService.mockFeeResponse);
+        .resolves(JSON.stringify(mockFeeReigsterService.mockFeeResponse));
       underTest.updateApplicationFeeMiddleware(req, res, () => {
         expect(ioRedisClient.get.calledOnce).to.eql(true);
         expect(ioRedisClient.set.calledOnce).to.eql(false);

--- a/app/middleware/updateApplicationFeeMiddleware.test.js
+++ b/app/middleware/updateApplicationFeeMiddleware.test.js
@@ -1,0 +1,58 @@
+const { expect, sinon } = require('test/util/chai');
+const rewire = require('rewire');
+const CONF = require('config');
+const mockFeeReigsterService = require('app/services/mocks/feeRegisterService');
+
+const modulePath = 'app/middleware/updateApplicationFeeMiddleware';
+const underTest = rewire(modulePath);
+
+let req = {};
+let res = {};
+const ioRedisClient = {};
+
+describe(modulePath, () => {
+  describe('#updateApplicationFeeMiddleware', () => {
+    beforeEach(() => {
+      ioRedisClient.get = sinon.stub().resolves();
+      ioRedisClient.set = sinon.stub().resolves();
+      ioRedisClient.expire = sinon.stub().resolves();
+      underTest.__set__('redisClient', ioRedisClient);
+      req = { session: {} };
+      res = { redirect: sinon.stub() };
+    });
+    it('gets application fee from fee register', done => {
+      underTest.updateApplicationFeeMiddleware(req, res, () => {
+        expect(ioRedisClient.get.calledOnce).to.eql(true);
+        expect(ioRedisClient.set.calledOnce).to.eql(true);
+        expect(ioRedisClient.expire.calledOnce).to.eql(true);
+        expect(CONF.commonProps.applicationFee)
+          .to.eql(mockFeeReigsterService.mockFeeResponse);
+        done();
+      });
+    });
+    it('gets application fee redis if available', done => {
+      ioRedisClient.get = sinon.stub()
+        .resolves(mockFeeReigsterService.mockFeeResponse);
+      underTest.updateApplicationFeeMiddleware(req, res, () => {
+        expect(ioRedisClient.get.calledOnce).to.eql(true);
+        expect(ioRedisClient.set.calledOnce).to.eql(false);
+        expect(ioRedisClient.expire.calledOnce).to.eql(false);
+        expect(CONF.commonProps.applicationFee)
+          .to.eql(mockFeeReigsterService.mockFeeResponse);
+        done();
+      });
+    });
+    it('catches error and redirects to res.redirect', done => {
+      ioRedisClient.get = sinon.stub().rejects(new Error());
+      const next = sinon.stub();
+      underTest.updateApplicationFeeMiddleware(req, res, next);
+      setImmediate(() => {
+        expect(ioRedisClient.get.calledOnce).to.eql(true);
+        expect(res.redirect.calledOnce).to.eql(true);
+        expect(next.calledOnce).to.eql(false);
+        expect(res.redirect.calledWith('/generic-error')).to.eql(true);
+        done();
+      });
+    });
+  });
+});

--- a/app/services/feeRegisterService.js
+++ b/app/services/feeRegisterService.js
@@ -1,0 +1,12 @@
+const request = require('request-promise-native');
+const CONF = require('config');
+
+const feeEndpoint = '/fees-register/fees/lookup';
+
+const get = ({ queryParameters = '' }) => {
+  const uri = `${CONF.services.feeRegister.baseUrl}${feeEndpoint}?${queryParameters}`;
+
+  return request.get({ uri, json: true });
+};
+
+module.exports = { get };

--- a/app/services/feeRegisterService.test.js
+++ b/app/services/feeRegisterService.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai').use(require('chai-as-promised'));
+const sinon = require('sinon');
+const request = require('request-promise-native');
+
+const modulePath = 'app/services/feeRegisterService';
+const underTest = require(modulePath);
+
+describe(modulePath, () => {
+  beforeEach(() => {
+    sinon.stub(request, 'get').resolves();
+  });
+
+  afterEach(() => {
+    request.get.restore();
+  });
+
+  it('should call the fee register service', done => {
+    underTest.get({})
+      .then(() => {
+        expect(request.get.calledOnce).to.eql(true);
+      })
+      .then(done, done);
+  });
+});

--- a/app/services/healthcheck.js
+++ b/app/services/healthcheck.js
@@ -70,6 +70,12 @@ router.get('/healthcheck', healthcheck.configure({
         return !error && res.status === OK ? outputs.up() : outputs.down(error);
       }
     }),
+    feeRegister: healthcheck.web(config.services.feeRegister.health, {
+      callback: (error, res) => { // eslint-disable-line id-blacklist
+        logger.error(`Health check failed on fee register: ${error}`);
+        return !error && res.status === OK ? outputs.up() : outputs.down(error);
+      }
+    }),
     features: healthcheck.raw(req => {
       return healthcheck.status(Object.keys(req.features) != 0, req.features); // eslint-disable-line eqeqeq
     })

--- a/app/services/healthcheck.js
+++ b/app/services/healthcheck.js
@@ -15,6 +15,9 @@ const client = ioRedis.createClient(
   config.services.redis.host,
   { enableOfflineQueue: false }
 );
+client.on('error', error => {
+  logger.error(error);
+});
 
 router.get('/healthcheck', healthcheck.configure({
   checks: {

--- a/app/services/mocks/feeRegisterService.js
+++ b/app/services/mocks/feeRegisterService.js
@@ -1,0 +1,14 @@
+const mockFeeResponse = {
+  code: 'X0165',
+  description: 'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.',
+  version: 1,
+  fee_amount: 550.00
+};
+
+const get = () => {
+  return new Promise(resolve => {
+    resolve(mockFeeResponse);
+  });
+};
+
+module.exports = { get, mockFeeResponse };

--- a/app/services/mocks/ioRedis.js
+++ b/app/services/mocks/ioRedis.js
@@ -1,0 +1,17 @@
+const ioRedis = () => {
+  const client = {};
+
+  const func = () => {
+    return new Promise(resolve => {
+      resolve();
+    });
+  };
+  client.on = func;
+  client.set = func;
+  client.expire = func;
+  client.get = func;
+
+  return client;
+};
+
+module.exports = ioRedis;

--- a/app/services/rateLimiter.js
+++ b/app/services/rateLimiter.js
@@ -1,11 +1,15 @@
 const CONF = require('config');
 const ioRedis = require('ioredis');
 const expressLimiter = require('express-limiter');
+const logger = require('@hmcts/nodejs-logging').getLogger(__filename);
 
 const redisHost = process.env.REDISCLOUD_URL || CONF.services.redis.host;
 
 module.exports = app => {
   const client = ioRedis.createClient(redisHost);
+  client.on('error', error => {
+    logger.error(error);
+  });
   const limiter = expressLimiter(app, client);
 
   return limiter({

--- a/app/services/submission.js
+++ b/app/services/submission.js
@@ -54,7 +54,7 @@ const generatePaymentEventData = (session, response) => {
       PaymentDate: formatDate(dateCreated),
       PaymentAmount: amount,
       PaymentStatus: paymentStatus,
-      PaymentFeeId: CONF.commonProps.applicationFeeCode,
+      PaymentFeeId: CONF.commonProps.applicationFee.code,
       PaymentSiteId: siteId
     }
   };

--- a/app/services/submission.test.js
+++ b/app/services/submission.test.js
@@ -96,7 +96,7 @@ describe(modulePath, () => {
         court: { someCourt: { siteId: 'XX00' } }
       };
       originalCommonProps = CONF.commonProps;
-      CONF.commonProps = { applicationFeeCode: 'some-code' };
+      CONF.commonProps = { applicationFee: { code: 'some-code' } };
     });
 
     afterEach(() => {

--- a/app/steps/done/content.json
+++ b/app/steps/done/content.json
@@ -20,7 +20,7 @@
                     "proofOfName": "proof of your name change, for example a <a href=\"https://www.gov.uk/change-name-deed-poll/overview\" target=\"_blank\">deed poll</a>. Include proof of each change if you&#39;ve done it more than once since you got married",
                     "certified": "your original marriage certificate or a <a href=\"https://www.gov.uk/order-copy-birth-death-marriage-certificate\" target=\"_blank\">certified copy</a>",
                     "englishTranslation": "a <a href=\"https://www.gov.uk/certifying-a-document\" target=\"_blank\">certified English translation</a> of your marriage certificate",
-                    "cheque": "a cheque for £{{ applicationFee }} made out to HM Courts and Tribunals Service",
+                    "cheque": "a cheque for £{{ applicationFee.fee_amount }} made out to HM Courts and Tribunals Service",
                     "courtWillKeep": "The court will keep your marriage certificate.",
                     "postApplication": "3. Post your application to the court",
                     "postDescription": "Post the entire printed application pack",

--- a/app/steps/done/index.js
+++ b/app/steps/done/index.js
@@ -1,6 +1,6 @@
 const DestroySessionStep = require('app/core/DestroySessionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class Done extends DestroySessionStep {
   handler(req, res) {
@@ -12,7 +12,10 @@ module.exports = class Done extends DestroySessionStep {
   }
 
   get middleware() {
-    return [...super.middleware, updateApplicationFeeMiddleware];
+    return [
+      ...super.middleware,
+      applicationFeeMiddleware.updateApplicationFeeMiddleware
+    ];
   }
 
   * interceptor(ctx, session) {

--- a/app/steps/done/index.js
+++ b/app/steps/done/index.js
@@ -1,5 +1,6 @@
 const DestroySessionStep = require('app/core/DestroySessionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class Done extends DestroySessionStep {
   handler(req, res) {
@@ -8,6 +9,10 @@ module.exports = class Done extends DestroySessionStep {
 
   get url() {
     return '/done';
+  }
+
+  get middleware() {
+    return [...super.middleware, updateApplicationFeeMiddleware];
   }
 
   * interceptor(ctx, session) {

--- a/app/steps/done/index.test.js
+++ b/app/steps/done/index.test.js
@@ -3,6 +3,8 @@ const { testContent, testExistence, testNonExistence } = require('test/util/asse
 const { withSession } = require('test/util/setup');
 const server = require('app');
 const CONF = require('config');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const { expect } = require('test/util/chai');
 
 const modulePath = 'app/steps/done';
 
@@ -31,6 +33,12 @@ describe(modulePath, () => {
     featureTogglesMock.restore();
   });
 
+  describe('#middleware', () => {
+    it('returns updateApplicationFeeMiddleware in middleware', () => {
+      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+        .to.eql(true);
+    });
+  });
 
   describe('when name is on certificate', () => {
     let session = {};

--- a/app/steps/done/index.test.js
+++ b/app/steps/done/index.test.js
@@ -3,8 +3,8 @@ const { testContent, testExistence, testNonExistence } = require('test/util/asse
 const { withSession } = require('test/util/setup');
 const server = require('app');
 const CONF = require('config');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
-const { expect } = require('test/util/chai');
+const { expect, sinon } = require('test/util/chai');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 const modulePath = 'app/steps/done';
 
@@ -18,9 +18,12 @@ const featureTogglesMock = require('test/mocks/featureToggles');
 let s = {};
 let agent = {};
 let underTest = {};
+const two = 2;
 
 describe(modulePath, () => {
   beforeEach(() => {
+    sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
+      .callsArgWith(two);
     featureTogglesMock.stub();
     s = server.init();
     agent = request.agent(s.app);
@@ -31,11 +34,13 @@ describe(modulePath, () => {
   afterEach(() => {
     s.http.close();
     featureTogglesMock.restore();
+    applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
   });
 
   describe('#middleware', () => {
     it('returns updateApplicationFeeMiddleware in middleware', () => {
-      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+      expect(underTest.middleware
+        .includes(applicationFeeMiddleware.updateApplicationFeeMiddleware))
         .to.eql(true);
     });
   });

--- a/app/steps/help/need-help/content.json
+++ b/app/steps/help/need-help/content.json
@@ -6,7 +6,7 @@
 
                 "content": {
                     "question": "Do you want help paying your fee?",
-                    "explanation": "If you have little or no savings, are on certain benefits or have a low income you may be able to get help with paying the <strong>£{{ applicationFee }}</strong> fee.",
+                    "explanation": "If you have little or no savings, are on certain benefits or have a low income you may be able to get help with paying the <strong>£{{ applicationFee.fee_amount }}</strong> fee.",
                     "yes": "Yes",
                     "no": "No"
                 },

--- a/app/steps/help/need-help/index.js
+++ b/app/steps/help/need-help/index.js
@@ -1,5 +1,6 @@
 const OptionStep = require('app/core/OptionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class NeedHelpWithFees extends OptionStep {
   get url() {
@@ -12,6 +13,10 @@ module.exports = class NeedHelpWithFees extends OptionStep {
         No: this.steps.MarriageHusbandOrWife
       }
     };
+  }
+
+  get middleware() {
+    return [...super.middleware, updateApplicationFeeMiddleware];
   }
 
   handler(req, res) {

--- a/app/steps/help/need-help/index.js
+++ b/app/steps/help/need-help/index.js
@@ -1,6 +1,6 @@
 const OptionStep = require('app/core/OptionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class NeedHelpWithFees extends OptionStep {
   get url() {
@@ -16,7 +16,10 @@ module.exports = class NeedHelpWithFees extends OptionStep {
   }
 
   get middleware() {
-    return [...super.middleware, updateApplicationFeeMiddleware];
+    return [
+      ...super.middleware,
+      applicationFeeMiddleware.updateApplicationFeeMiddleware
+    ];
   }
 
   handler(req, res) {

--- a/app/steps/help/need-help/index.test.js
+++ b/app/steps/help/need-help/index.test.js
@@ -5,8 +5,8 @@ const {
 } = require('test/util/assertions');
 const server = require('app');
 const idamMock = require('test/mocks/idam');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
-const { expect } = require('test/util/chai');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
+const { expect, sinon } = require('test/util/chai');
 
 const modulePath = 'app/steps/help/need-help';
 
@@ -15,9 +15,12 @@ const content = require(`${modulePath}/content`);
 let s = {};
 let agent = {};
 let underTest = {};
+const two = 2;
 
 describe(modulePath, () => {
   beforeEach(() => {
+    sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
+      .callsArgWith(two);
     idamMock.stub();
     s = server.init();
     agent = request.agent(s.app);
@@ -28,11 +31,13 @@ describe(modulePath, () => {
   afterEach(() => {
     s.http.close();
     idamMock.restore();
+    applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
   });
 
   describe('#middleware', () => {
     it('returns updateApplicationFeeMiddleware in middleware', () => {
-      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+      expect(underTest.middleware
+        .includes(applicationFeeMiddleware.updateApplicationFeeMiddleware))
         .to.eql(true);
     });
   });

--- a/app/steps/help/need-help/index.test.js
+++ b/app/steps/help/need-help/index.test.js
@@ -5,6 +5,8 @@ const {
 } = require('test/util/assertions');
 const server = require('app');
 const idamMock = require('test/mocks/idam');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const { expect } = require('test/util/chai');
 
 const modulePath = 'app/steps/help/need-help';
 
@@ -28,6 +30,12 @@ describe(modulePath, () => {
     idamMock.restore();
   });
 
+  describe('#middleware', () => {
+    it('returns updateApplicationFeeMiddleware in middleware', () => {
+      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+        .to.eql(true);
+    });
+  });
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/index/content.json
+++ b/app/steps/index/content.json
@@ -30,7 +30,7 @@
                     "needToSend": "You'll need to send your marriage certificate and any translations or proof of name changes to the court with your application. The court won't return your marriage certificate.",
                     "alsoApply": "If you can&#39;t use this service, you can apply by filling in the <a href=\"https://www.gov.uk/divorce/file-for-divorce\" target=\"_blank\">paper D8 form</a>.",
                     "fees": "Fees",
-                    "costs": "The court fee for all divorces in England and Wales is £550.",
+                    "costs": "The court fee for all divorces in England and Wales is £{{ applicationFee.fee_amount }}.",
                     "needToPayOnline": "You need to pay online by debit or credit card to use this service.",
                     "youCan": "You can pay by: ",
                     "creditCard": "credit or debit card over the phone",

--- a/app/steps/index/index.js
+++ b/app/steps/index/index.js
@@ -1,6 +1,7 @@
 const Step = require('app/core/Step');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const initSession = require('app/middleware/initSession');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class Index extends Step {
   get url() {
@@ -11,7 +12,7 @@ module.exports = class Index extends Step {
   }
 
   get middleware() {
-    return [initSession];
+    return [initSession, updateApplicationFeeMiddleware];
   }
 
   handler(req, res) {

--- a/app/steps/index/index.js
+++ b/app/steps/index/index.js
@@ -1,7 +1,7 @@
 const Step = require('app/core/Step');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const initSession = require('app/middleware/initSession');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class Index extends Step {
   get url() {
@@ -12,7 +12,10 @@ module.exports = class Index extends Step {
   }
 
   get middleware() {
-    return [initSession, updateApplicationFeeMiddleware];
+    return [
+      initSession,
+      applicationFeeMiddleware.updateApplicationFeeMiddleware
+    ];
   }
 
   handler(req, res) {

--- a/app/steps/index/index.test.js
+++ b/app/steps/index/index.test.js
@@ -1,6 +1,8 @@
 const request = require('supertest');
 const { testContent, testRedirect, testNonExistence } = require('test/util/assertions');
 const server = require('app');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
+const { expect, sinon } = require('test/util/chai');
 
 const modulePath = 'app/steps/index';
 const content = require(`${modulePath}/content`);
@@ -14,9 +16,12 @@ const { features } = require('@hmcts/div-feature-toggle-client')().featureToggle
 let s = {};
 let agent = {};
 let underTest = {};
+const two = 2;
 
 describe(modulePath, () => {
   beforeEach(() => {
+    sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
+      .callsArgWith(two);
     featureTogglesMock.stub();
     s = server.init();
     agent = request.agent(s.app);
@@ -27,6 +32,15 @@ describe(modulePath, () => {
   afterEach(() => {
     s.http.close();
     featureTogglesMock.restore();
+    applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
+  });
+
+  describe('#middleware', () => {
+    it('returns updateApplicationFeeMiddleware in middleware', () => {
+      expect(underTest.middleware
+        .includes(applicationFeeMiddleware.updateApplicationFeeMiddleware))
+        .to.eql(true);
+    });
   });
 
   describe('success', () => {

--- a/app/steps/pay/by-card/index.js
+++ b/app/steps/pay/by-card/index.js
@@ -11,6 +11,7 @@ const serviceTokenService = require('app/services/serviceToken');
 const paymentService = require('app/services/payment');
 const submissionService = require('app/services/submission');
 const getBaseUrl = require('app/core/utils/baseUrl');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class PayByCard extends Step {
   get middleware() {
@@ -18,7 +19,7 @@ module.exports = class PayByCard extends Step {
       return features.idam ? protect()(req, res, next) : next();
     };
 
-    return [idamProtect];
+    return [idamProtect, updateApplicationFeeMiddleware];
   }
 
   handler(req, res) {
@@ -51,11 +52,12 @@ module.exports = class PayByCard extends Step {
 
     // Fee properties below are hardcoded and obtained from config.
     // Eventually these values will be obtained from the fees-register.
-    const feeCode = CONF.commonProps.applicationFeeCode;
+    const feeCode = CONF.commonProps.applicationFee.code;
     const feeDescription = 'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.';
     // Amount is specified in pence.
     const PENCE_PER_POUND = 100;
-    const amount = parseInt(CONF.commonProps.applicationFee) * PENCE_PER_POUND;
+    const amount = parseInt(CONF.commonProps.applicationFee
+      .fee_amount) * PENCE_PER_POUND;
     const returnUrl = `${getBaseUrl()}${this.steps.CardPaymentStatus.url}`;
     const caseId = req.session.caseId;
     const siteId = get(req.session, `court.${req.session.courts}.siteId`);

--- a/app/steps/pay/by-card/index.js
+++ b/app/steps/pay/by-card/index.js
@@ -11,7 +11,7 @@ const serviceTokenService = require('app/services/serviceToken');
 const paymentService = require('app/services/payment');
 const submissionService = require('app/services/submission');
 const getBaseUrl = require('app/core/utils/baseUrl');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class PayByCard extends Step {
   get middleware() {
@@ -19,7 +19,10 @@ module.exports = class PayByCard extends Step {
       return features.idam ? protect()(req, res, next) : next();
     };
 
-    return [idamProtect, updateApplicationFeeMiddleware];
+    return [
+      idamProtect,
+      applicationFeeMiddleware.updateApplicationFeeMiddleware
+    ];
   }
 
   handler(req, res) {

--- a/app/steps/pay/by-card/index.test.js
+++ b/app/steps/pay/by-card/index.test.js
@@ -12,7 +12,7 @@ const jwt = require('jsonwebtoken');
 const serviceToken = require('app/services/serviceToken');
 const payment = require('app/services/payment');
 const submission = require('app/services/submission');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 const modulePath = 'app/steps/pay/by-card';
 
@@ -20,6 +20,7 @@ let s = {};
 let agent = {};
 let underTest = {};
 let cookies = [];
+const two = 2;
 
 describe(modulePath, () => {
   let getToken = null;
@@ -49,6 +50,8 @@ describe(modulePath, () => {
     sinon.stub(payment, 'setup').returns({ create });
     sinon.stub(submission, 'setup').returns({ update });
     sinon.stub(jwt, 'decode').returns({ id: 1 });
+    sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
+      .callsArgWith(two);
 
     idamMock.stub();
     featureTogglesMock.stub();
@@ -58,6 +61,7 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
+    applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
     s.http.close();
     featureTogglesMock.restore();
     idamMock.restore();
@@ -70,7 +74,8 @@ describe(modulePath, () => {
 
   describe('#middleware', () => {
     it('returns updateApplicationFeeMiddleware in middleware', () => {
-      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+      expect(underTest.middleware
+        .includes(applicationFeeMiddleware.updateApplicationFeeMiddleware))
         .to.eql(true);
     });
   });

--- a/app/steps/pay/by-card/index.test.js
+++ b/app/steps/pay/by-card/index.test.js
@@ -12,6 +12,7 @@ const jwt = require('jsonwebtoken');
 const serviceToken = require('app/services/serviceToken');
 const payment = require('app/services/payment');
 const submission = require('app/services/submission');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 const modulePath = 'app/steps/pay/by-card';
 
@@ -65,6 +66,13 @@ describe(modulePath, () => {
     submission.setup.restore();
     payment.setup.restore();
     serviceToken.setup.restore();
+  });
+
+  describe('#middleware', () => {
+    it('returns updateApplicationFeeMiddleware in middleware', () => {
+      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+        .to.eql(true);
+    });
   });
 
   describe('handler', () => {

--- a/app/steps/pay/how/content.json
+++ b/app/steps/pay/how/content.json
@@ -5,7 +5,7 @@
             "translation": {
                 "content": {
                     "question": "How do you want to pay your application fee?",
-                    "applicationFee": "The application fee is £{{ applicationFee }}.",
+                    "applicationFee": "The application fee is £{{ applicationFee.fee_amount }}.",
                     "byCheque": "By cheque",
                     "byCardOverPhoneCourt": "By debit or credit card (the court will call to take payment)"
                 },

--- a/app/steps/pay/how/index.js
+++ b/app/steps/pay/how/index.js
@@ -1,6 +1,7 @@
 const OptionStep = require('app/core/OptionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const { watch } = require('app/core/staleDataManager');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class PayHow extends OptionStep {
   get enabledAfterSubmission() {
@@ -9,6 +10,10 @@ module.exports = class PayHow extends OptionStep {
 
   get url() {
     return '/pay/how';
+  }
+
+  get middleware() {
+    return [...super.middleware, updateApplicationFeeMiddleware];
   }
 
   get nextStep() {

--- a/app/steps/pay/how/index.js
+++ b/app/steps/pay/how/index.js
@@ -1,7 +1,7 @@
 const OptionStep = require('app/core/OptionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const { watch } = require('app/core/staleDataManager');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class PayHow extends OptionStep {
   get enabledAfterSubmission() {
@@ -13,7 +13,10 @@ module.exports = class PayHow extends OptionStep {
   }
 
   get middleware() {
-    return [...super.middleware, updateApplicationFeeMiddleware];
+    return [
+      ...super.middleware,
+      applicationFeeMiddleware.updateApplicationFeeMiddleware
+    ];
   }
 
   get nextStep() {

--- a/app/steps/pay/how/index.test.js
+++ b/app/steps/pay/how/index.test.js
@@ -8,18 +8,21 @@ const {
 
 const modulePath = 'app/steps/pay/how';
 const { removeStaleData } = require('app/core/staleDataManager');
-const { expect } = require('test/util/chai');
+const { expect, sinon } = require('test/util/chai');
 const { clone } = require('lodash');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 const content = require(`${modulePath}/content`);
 
 let s = {};
 let agent = {};
 let underTest = {};
+const two = 2;
 
 describe(modulePath, () => {
   beforeEach(() => {
+    sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
+      .callsArgWith(two);
     idamMock.stub();
     s = server.init();
     agent = request.agent(s.app);
@@ -28,6 +31,7 @@ describe(modulePath, () => {
 
 
   afterEach(() => {
+    applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
     s.http.close();
     idamMock.restore();
   });
@@ -35,7 +39,8 @@ describe(modulePath, () => {
 
   describe('#middleware', () => {
     it('returns updateApplicationFeeMiddleware in middleware', () => {
-      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+      expect(underTest.middleware
+        .includes(applicationFeeMiddleware.updateApplicationFeeMiddleware))
         .to.eql(true);
     });
   });

--- a/app/steps/pay/how/index.test.js
+++ b/app/steps/pay/how/index.test.js
@@ -10,6 +10,7 @@ const modulePath = 'app/steps/pay/how';
 const { removeStaleData } = require('app/core/staleDataManager');
 const { expect } = require('test/util/chai');
 const { clone } = require('lodash');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 const content = require(`${modulePath}/content`);
 
@@ -31,6 +32,13 @@ describe(modulePath, () => {
     idamMock.restore();
   });
 
+
+  describe('#middleware', () => {
+    it('returns updateApplicationFeeMiddleware in middleware', () => {
+      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+        .to.eql(true);
+    });
+  });
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/pay/how/template.html
+++ b/app/steps/pay/how/template.html
@@ -14,7 +14,7 @@
   </legend>
 
   <p class="text">
-    {{ content.applicationFee }}
+    {{ content.applicationFee.fee_amount }}
   </p>
 
   <div id="paymentMethod" class="form-group{{' error' if fields.paymentMethod.error }}">

--- a/app/steps/pay/how/template.html
+++ b/app/steps/pay/how/template.html
@@ -14,7 +14,7 @@
   </legend>
 
   <p class="text">
-    {{ content.applicationFee.fee_amount }}
+    {{ content.applicationFee }}
   </p>
 
   <div id="paymentMethod" class="form-group{{' error' if fields.paymentMethod.error }}">

--- a/app/steps/pay/pay-online-only/content.json
+++ b/app/steps/pay/pay-online-only/content.json
@@ -5,7 +5,7 @@
             "translation": {
                 "content": {
                     "question": "Payment",
-                    "applicationFee": "The application fee is £{{ applicationFee }}. The payment can be made by anyone with a valid debit or credit card.",
+                    "applicationFee": "The application fee is £{{ applicationFee.fee_amount }}. The payment can be made by anyone with a valid debit or credit card.",
                     "claimingCosts": "If you're claiming the divorce costs from your {{ divorceWho }}, this fee can be included in any costs order the court makes."
                 }
             }

--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -1,7 +1,7 @@
 const Step = require('app/core/Step');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const { features } = require('@hmcts/div-feature-toggle-client')().featureToggles;
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class PayOnline extends Step {
   get url() {
@@ -13,7 +13,7 @@ module.exports = class PayOnline extends Step {
   }
 
   get middleware() {
-    return [updateApplicationFeeMiddleware];
+    return [applicationFeeMiddleware.updateApplicationFeeMiddleware];
   }
 
   handler(req, res) {

--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -1,6 +1,7 @@
 const Step = require('app/core/Step');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const { features } = require('@hmcts/div-feature-toggle-client')().featureToggles;
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
 
 module.exports = class PayOnline extends Step {
   get url() {
@@ -9,6 +10,10 @@ module.exports = class PayOnline extends Step {
 
   get nextStep() {
     return features.onlineSubmission ? this.steps.PayByCard : this.steps.PayHow;
+  }
+
+  get middleware() {
+    return [updateApplicationFeeMiddleware];
   }
 
   handler(req, res) {

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -3,6 +3,8 @@ const server = require('app');
 const idamMock = require('test/mocks/idam');
 const { testContent, testRedirect } = require('test/util/assertions');
 const featureTogglesMock = require('test/mocks/featureToggles');
+const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
+const { expect } = require('test/util/chai');
 
 const modulePath = 'app/steps/pay/pay-online-only';
 
@@ -28,6 +30,13 @@ describe(modulePath, () => {
     featureTogglesMock.restore();
   });
 
+
+  describe('#middleware', () => {
+    it('returns updateApplicationFeeMiddleware in middleware', () => {
+      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+        .to.eql(true);
+    });
+  });
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -3,8 +3,8 @@ const server = require('app');
 const idamMock = require('test/mocks/idam');
 const { testContent, testRedirect } = require('test/util/assertions');
 const featureTogglesMock = require('test/mocks/featureToggles');
-const { updateApplicationFeeMiddleware } = require('app/middleware/updateApplicationFeeMiddleware');
-const { expect } = require('test/util/chai');
+const applicationFeeMiddleware = require('app/middleware/updateApplicationFeeMiddleware');
+const { expect, sinon } = require('test/util/chai');
 
 const modulePath = 'app/steps/pay/pay-online-only';
 
@@ -13,9 +13,12 @@ const content = require(`${modulePath}/content`);
 let s = {};
 let agent = {};
 let underTest = {};
+const two = 2;
 
 describe(modulePath, () => {
   beforeEach(() => {
+    sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
+      .callsArgWith(two);
     featureTogglesMock.stub();
     idamMock.stub();
     s = server.init();
@@ -28,12 +31,14 @@ describe(modulePath, () => {
     s.http.close();
     idamMock.restore();
     featureTogglesMock.restore();
+    applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
   });
 
 
   describe('#middleware', () => {
     it('returns updateApplicationFeeMiddleware in middleware', () => {
-      expect(underTest.middleware.includes(updateApplicationFeeMiddleware))
+      expect(underTest.middleware
+        .includes(applicationFeeMiddleware.updateApplicationFeeMiddleware))
         .to.eql(true);
     });
   });

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -33,6 +33,9 @@ services:
     health: SERVICE_AUTH_PROVIDER_HEALTHCHECK_URL
     microserviceName: MICROSERVICE_NAME
     microserviceKey: MICROSERVICE_KEY
+  feeRegister:
+    baseUrl: FEE_REGISTER_URL
+    health: FEE_REGISTER_HEALTHCHECK_URL
 
 secret: SECRET
 sessionEncryptionSecret: SESSION_ENCRYPTION_SECRET

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -72,7 +72,6 @@ commonProps:
     version: 1
     fee_amount: 550.00
   financialOrderApplicationFee: 255
-  applicationFeeCode: 'X0165'
   court:
     eastMidlands:
       phone: '0000 111 2220'

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -52,6 +52,10 @@ services:
     baseUrl: 'http://localhost:4003/transformationapi/version/1'
     draftBaseUrl: 'http://localhost:4003/draftsapi/version/1'
     health: 'http://localhost:4003/status/health'
+  feeRegister:
+    baseUrl: 'http://localhost:4421'
+    health: 'http://localhost:4421/health'
+    TTL: 259200 # time to save fee register records in seconds ( 3 days = 259200 )
 
 defaultEnvironmentNodeEnv: 'development'
 
@@ -62,7 +66,11 @@ dateFormat: 'DD/MM/YYYY'
 paymentDateFormat: 'DDMMYYYY'
 
 commonProps:
-  applicationFee: 550
+  applicationFee: 
+    code: 'X0165'
+    description: 'Divorce fee'
+    version: 1
+    fee_amount: 550.00
   financialOrderApplicationFee: 255
   applicationFeeCode: 'X0165'
   court:


### PR DESCRIPTION
[DIV-1976 - Retrieve divorce application fee from Fee Register](https://tools.hmcts.net/jira/browse/DIV-1976)

#### What this change does?
 - Adds service to retrieve fee for divorce
 - Adds middleware to enable any page that requires fee to retrieve it & cache in redis
 - Adds new middleware to all pages requiring divorce fee
 - Updates new fee config