### PR TITLE
Div 2000 logout

### DIFF
--- a/app/core/DestroySessionStep.js
+++ b/app/core/DestroySessionStep.js
@@ -1,4 +1,5 @@
 const Step = require('./Step');
+const { logout } = require('app/services/idam');
 
 module.exports = class DestroySessionStep extends Step {
   * interceptor(ctx, session) {
@@ -9,6 +10,10 @@ module.exports = class DestroySessionStep extends Step {
     });
 
     return ctx;
+  }
+
+  get middleware() {
+    return [logout()];
   }
 
   get nextStep() {

--- a/app/core/DestroySessionStep.js
+++ b/app/core/DestroySessionStep.js
@@ -1,5 +1,5 @@
 const Step = require('./Step');
-const { logout } = require('app/services/idam');
+const idam = require('app/services/idam');
 
 module.exports = class DestroySessionStep extends Step {
   * interceptor(ctx, session) {
@@ -13,7 +13,7 @@ module.exports = class DestroySessionStep extends Step {
   }
 
   get middleware() {
-    return [logout()];
+    return [idam.logout()];
   }
 
   get nextStep() {

--- a/app/core/DestroySessionStep.test.js
+++ b/app/core/DestroySessionStep.test.js
@@ -1,4 +1,5 @@
 const { expect, sinon } = require('test/util/chai');
+const idam = require('app/services/idam');
 
 const modulePath = 'app/core/DestroySessionStep';
 const UnderTest = require(modulePath);
@@ -31,6 +32,18 @@ describe(modulePath, () => {
     expect(output.value)
       .to.be.fulfilled
       .and.notify(done);
+  });
+
+  it('returns logout middleware', () => {
+    const logoutStub = sinon.stub();
+    sinon.stub(idam, 'logout').returns(logoutStub);
+
+    // Act.
+    const output = step.middleware;
+    // Assert.
+    expect(output).to.eql([logoutStub]);
+
+    idam.logout.restore();
   });
 
   it('rejects if session destroy returns an error', done => {

--- a/app/services/idam.js
+++ b/app/services/idam.js
@@ -28,6 +28,9 @@ module.exports = {
   },
   protect: () => {
     return idamExpressMiddleware.protect(idamArgs);
+  },
+  logout: () => {
+    return idamExpressMiddleware.logout(idamArgs);
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@hmcts/div-feature-toggle-client": "https://github.com/hmcts/div-feature-toggle-client#1.0.7",
-    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#3.0.4",
+    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#3.0.5",
     "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#4.0.4",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#2.1.4",
     "@hmcts/nodejs-healthcheck": "^1.2.0",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-2000

Add Login functionality to the divorce application on save&close, exit and done.

This is the frontend bit of the code. It requires the corresponding idam express middleware to be built and added to node modules for this to work..

DestroySessionStep has been updated to make a middleware call to idam to delete session token.