### PR TITLE
fix save and close bug

### DIFF
--- a/app/components/AddressLookupStep/index.js
+++ b/app/components/AddressLookupStep/index.js
@@ -25,6 +25,10 @@ module.exports = class AddressLookupStep extends ValidationStep {
       set(session, `${this.schemaScope}.selectAddressIndex`, ctx.selectAddressIndex);
     }
 
+    if (ctx.searchPostcode && ctx.searchPostcode !== 'false') {
+      unset(session, `${this.schemaScope}`);
+    }
+
     // save address type directly to session
 
     if (ctx.addressType) {


### PR DESCRIPTION
[DIV-2201 - Throwing Generic Error when click on SaveAndClose button](https://tools.hmcts.net/jira/browse/DIV-2201)

#### What this change does?

Bug fix for issue regarding save and close, bug details:

Dominic Taylor, when I tried to complete the journey after resuming from the steps in the bug, you end up with a broken address page (see below screenshot), and trying to continue causes a "No addresses found error"

Steps to recreate:

 - resume a previously saved divorce (that was saved on the /petitioner-respondent/address page with 
 - empty address details as per the original bug)
 - enter postcode and click 'find address'
 - ISSUE 1: page loads with 2 'save and close' links
 - select an address from the drop-down list
 - ISSUE 2: page loads with an error message "No addresses found. Enter a postcode to search again" even though you selected a found address