### PR TITLE
Fix flow of adultery when and where to include default statement when No

### DIFF
--- a/app/steps/grounds-for-divorce/adultery/details/index.js
+++ b/app/steps/grounds-for-divorce/adultery/details/index.js
@@ -27,18 +27,6 @@ module.exports = class AdulteryDetails extends ValidationStep {
         );
       }
     });
-
-    watch('reasonForDivorceAdulteryKnowWhen', (previousSession, session, remove) => {
-      if (session.reasonForDivorceAdulteryKnowWhen !== 'Yes') {
-        remove('reasonForDivorceAdulteryWhenDetails');
-      }
-    });
-
-    watch('reasonForDivorceAdulteryKnowWhere', (previousSession, session, remove) => {
-      if (session.reasonForDivorceAdulteryKnowWhere !== 'Yes') {
-        remove('reasonForDivorceAdulteryWhereDetails');
-      }
-    });
   }
 
   * validate(ctx, session) {

--- a/app/steps/grounds-for-divorce/adultery/details/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/details/index.test.js
@@ -252,66 +252,6 @@ describe(modulePath, () => {
       expect(newSession.reasonForDivorceAdulteryWhereDetails)
         .to.equal(previousSession.reasonForDivorceAdulteryWhereDetails);
     });
-
-    it('removes reasonForDivorceAdulteryWhereDetails if reasonForDivorceAdulteryKnowWhere is set to no', () => {
-      const previousSession = {
-        reasonForDivorceAdulteryKnowWhere: 'Yes',
-        reasonForDivorceAdulteryWhereDetails: 'Details...'
-      };
-
-      const session = clone(previousSession);
-      session.reasonForDivorceAdulteryKnowWhere = 'No';
-
-      const newSession = removeStaleData(previousSession, session);
-      expect(newSession.reasonForDivorceAdulteryKnowWhere).to.equal('No');
-      expect(typeof newSession.reasonForDivorceAdulteryWhereDetails)
-        .to.equal('undefined');
-    });
-
-    it('does not remove reasonForDivorceAdulteryWhereDetails if reasonForDivorceAdulteryKnowWhere is set to yes', () => {
-      const previousSession = {
-        reasonForDivorceAdulteryKnowWhere: 'No',
-        reasonForDivorceAdulteryWhereDetails: 'Details...'
-      };
-
-      const session = clone(previousSession);
-      session.reasonForDivorceAdulteryKnowWhere = 'Yes';
-
-      const newSession = removeStaleData(previousSession, session);
-      expect(newSession.reasonForDivorceAdulteryKnowWhere).to.equal('Yes');
-      expect(newSession.reasonForDivorceAdulteryWhereDetails)
-        .to.equal(previousSession.reasonForDivorceAdulteryWhereDetails);
-    });
-
-    it('removes reasonForDivorceAdulteryWhenDetails if reasonForDivorceAdulteryKnowWhen is set to no', () => {
-      const previousSession = {
-        reasonForDivorceAdulteryKnowWhen: 'Yes',
-        reasonForDivorceAdulteryWhenDetails: 'Details...'
-      };
-
-      const session = clone(previousSession);
-      session.reasonForDivorceAdulteryKnowWhen = 'No';
-
-      const newSession = removeStaleData(previousSession, session);
-      expect(newSession.reasonForDivorceAdulteryKnowWhen).to.equal('No');
-      expect(typeof newSession.reasonForDivorceAdulteryWhenDetails)
-        .to.equal('undefined');
-    });
-
-    it('does not remove reasonForDivorceAdulteryWhenDetails if reasonForDivorceAdulteryKnowWhen is set to yes', () => {
-      const previousSession = {
-        reasonForDivorceAdulteryKnowWhen: 'No',
-        reasonForDivorceAdulteryWhenDetails: 'Details...'
-      };
-
-      const session = clone(previousSession);
-      session.reasonForDivorceAdulteryKnowWhen = 'Yes';
-
-      const newSession = removeStaleData(previousSession, session);
-      expect(newSession.reasonForDivorceAdulteryKnowWhen).to.equal('Yes');
-      expect(newSession.reasonForDivorceAdulteryWhenDetails)
-        .to.equal(previousSession.reasonForDivorceAdulteryWhenDetails);
-    });
   });
 
   describe('Check Your Answers', () => {

--- a/app/steps/grounds-for-divorce/adultery/details/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/details/index.test.js
@@ -273,6 +273,8 @@ describe(modulePath, () => {
       ];
 
       const context = {
+        reasonForDivorceAdulteryKnowWhen: 'Yes',
+        reasonForDivorceAdulteryKnowWhere: 'Yes',
         reasonForDivorceAdulteryWhereDetails: 'details where',
         reasonForDivorceAdulteryWhenDetails: 'details when',
         reasonForDivorceAdulteryDetails: 'details plain'
@@ -287,7 +289,10 @@ describe(modulePath, () => {
 
       const valuesToExist = ['reasonForDivorceAdulteryWhenDetails'];
 
-      const context = { reasonForDivorceAdulteryWhenDetails: 'details...' };
+      const context = {
+        reasonForDivorceAdulteryWhenDetails: 'details...',
+        reasonForDivorceAdulteryKnowWhen: 'Yes'
+      };
 
       testExistenceCYA(done, underTest, content,
         contentToExist, valuesToExist, context);
@@ -298,7 +303,10 @@ describe(modulePath, () => {
 
       const valuesToExist = ['reasonForDivorceAdulteryWhereDetails'];
 
-      const context = { reasonForDivorceAdulteryWhereDetails: 'details...' };
+      const context = {
+        reasonForDivorceAdulteryWhereDetails: 'details...',
+        reasonForDivorceAdulteryKnowWhere: 'Yes'
+      };
 
       testExistenceCYA(done, underTest, content,
         contentToExist, valuesToExist, context);
@@ -320,7 +328,11 @@ describe(modulePath, () => {
 
       const valuesToNotExist = ['reasonForDivorceAdulteryWhereDetails'];
 
-      const context = { reasonForDivorceAdulteryDetails: 'details...' };
+      const context = {
+        reasonForDivorceAdulteryDetails: 'details...',
+        reasonForDivorceAdulteryWhereDetails: 'details...',
+        reasonForDivorceAdulteryKnowWhere: 'No'
+      };
 
       testNoneExistenceCYA(done, underTest, content,
         contentToNotExist, valuesToNotExist, context);
@@ -331,7 +343,11 @@ describe(modulePath, () => {
 
       const valuesToNotExist = ['reasonForDivorceAdulteryWhenDetails'];
 
-      const context = { reasonForDivorceAdulteryDetails: 'details...' };
+      const context = {
+        reasonForDivorceAdulteryDetails: 'details...',
+        reasonForDivorceAdulteryWhenDetails: 'details...',
+        reasonForDivorceAdulteryKnowWhen: 'No'
+      };
 
       testNoneExistenceCYA(done, underTest, content,
         contentToNotExist, valuesToNotExist, context);

--- a/app/steps/grounds-for-divorce/adultery/details/partials/checkYourAnswersTemplate.html
+++ b/app/steps/grounds-for-divorce/adultery/details/partials/checkYourAnswersTemplate.html
@@ -1,11 +1,11 @@
-{% if fields.reasonForDivorceAdulteryWhenDetails.value %}
+{% if fields.reasonForDivorceAdulteryKnowWhen.value == 'Yes' %}
   <tr>
     <th>{{ content.whenDidAdulteryHappen | safe }}</th>
     <td>{{ fields.reasonForDivorceAdulteryWhenDetails.value }}</td>
     <td><a class="link" href="{{ content.url | safe }}">{{ content.change }}</a></td>
   </tr>
 {% endif %}
-{% if fields.reasonForDivorceAdulteryWhereDetails.value %}
+{% if fields.reasonForDivorceAdulteryKnowWhere.value == 'Yes' %}
   <tr>
     <th>{{ content.whereDidAdulteryHappen | safe }}</th>
     <td>{{ fields.reasonForDivorceAdulteryWhereDetails.value }}</td>

--- a/app/steps/grounds-for-divorce/adultery/when/index.js
+++ b/app/steps/grounds-for-divorce/adultery/when/index.js
@@ -36,9 +36,4 @@ module.exports = class AdulteryWhen extends ValidationStep {
 
     return [ctx, session];
   }
-
-  // disable check your answers
-  get checkYourAnswersTemplate() {
-    return false;
-  }
 };

--- a/app/steps/grounds-for-divorce/adultery/when/index.js
+++ b/app/steps/grounds-for-divorce/adultery/when/index.js
@@ -21,5 +21,24 @@ module.exports = class AdulteryWhen extends ValidationStep {
         remove('reasonForDivorceAdulteryKnowWhen');
       }
     });
+
+    watch('reasonForDivorceAdulteryKnowWhen', (previousSession, session, remove) => {
+      if (previousSession.reasonForDivorceAdulteryKnowWhen === 'No') {
+        remove('reasonForDivorceAdulteryWhenDetails');
+      }
+    });
+  }
+
+  action(ctx, session) {
+    if (ctx.reasonForDivorceAdulteryKnowWhen === 'No') {
+      session.reasonForDivorceAdulteryWhenDetails = 'The applicant does not know when the adultery took place';
+    }
+
+    return [ctx, session];
+  }
+
+  // disable check your answers
+  get checkYourAnswersTemplate() {
+    return false;
   }
 };

--- a/app/steps/grounds-for-divorce/adultery/when/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/when/index.test.js
@@ -2,7 +2,7 @@
 const request = require('supertest');
 const {
   testContent, testErrors, testRedirect,
-  testDisabledCYATemplate,
+  testCYATemplate, testExistenceCYA,
   postData, expectSessionValue
 } = require('test/util/assertions');
 const { withSession } = require('test/util/setup');
@@ -182,8 +182,19 @@ describe(modulePath, () => {
   });
 
   describe('Check Your Answers', () => {
-    it('does not renders the cya template', done => {
-      testDisabledCYATemplate(done, underTest);
+    it('renders the cya template', done => {
+      testCYATemplate(done, underTest);
+    });
+
+    it('renders adultery when details', done => {
+      const contentToExist = [ 'question' ];
+
+      const valuesToExist = ['reasonForDivorceAdulteryKnowWhen'];
+
+      const context = { reasonForDivorceAdulteryKnowWhen: 'Yes' };
+
+      testExistenceCYA(done, underTest, content,
+        contentToExist, valuesToExist, context);
     });
   });
 });

--- a/app/steps/grounds-for-divorce/adultery/when/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/when/index.test.js
@@ -2,7 +2,8 @@
 const request = require('supertest');
 const {
   testContent, testErrors, testRedirect,
-  testCYATemplate, testExistenceCYA
+  testDisabledCYATemplate,
+  postData, expectSessionValue
 } = require('test/util/assertions');
 const { withSession } = require('test/util/setup');
 const server = require('app');
@@ -52,21 +53,54 @@ describe(modulePath, () => {
       testErrors(done, agent, underTest, context, content, 'required');
     });
 
-    it('redirects to the next page', done => {
+    it('redirects to the next page when the user knows when', done => {
       const context = { reasonForDivorceAdulteryKnowWhen: 'Yes' };
 
       testRedirect(done, agent, underTest, context, s.steps.AdulteryDetails);
     });
 
-    it('redirects to the exit page', done => {
+    it('redirects to the next page when user does not know when', done => {
       const context = { reasonForDivorceAdulteryKnowWhen: 'No' };
 
       testRedirect(done, agent, underTest, context, s.steps.AdulteryDetails);
     });
   });
 
+  describe('setting details on session', () => {
+    beforeEach(done => {
+      const session = { divorceWho: 'wife', reasonForDivorceAdulteryWhenDetails: 'placeholder' };
+      withSession(done, agent, session);
+    });
+
+    it('does not modify when details when user knows when', done => {
+      const context = { reasonForDivorceAdulteryKnowWhen: 'Yes' };
+
+      postData(agent, underTest.url, context).then(
+        expectSessionValue(
+          'reasonForDivorceAdulteryWhenDetails',
+          'placeholder',
+          agent,
+          done
+        )
+      );
+    });
+
+    it('sets the know when details when user does not know when', done => {
+      const context = { reasonForDivorceAdulteryKnowWhen: 'No' };
+
+      postData(agent, underTest.url, context).then(
+        expectSessionValue(
+          'reasonForDivorceAdulteryWhenDetails',
+          'The applicant does not know when the adultery took place',
+          agent,
+          done
+        )
+      );
+    });
+  });
+
   describe('Watched session values', () => {
-    it('removes reasonForDivorceAdulteryKnowWhere if reasonForDivorceAdulteryWishToName is set to No', () => {
+    it('removes reasonForDivorceAdulteryKnowWhen if reasonForDivorceAdulteryWishToName is set to No', () => {
       const previousSession = {
         reasonForDivorceAdulteryWishToName: 'Yes',
         reasonForDivorceAdulteryKnowWhen: 'Yes'
@@ -78,6 +112,8 @@ describe(modulePath, () => {
       const newSession = removeStaleData(previousSession, session);
       expect(newSession.reasonForDivorceAdulteryWishToName).to.equal('No');
       expect(typeof newSession.reasonForDivorceAdulteryKnowWhen)
+        .to.equal('undefined');
+      expect(typeof newSession.reasonForDivorceAdulteryWhenDetails)
         .to.equal('undefined');
     });
 
@@ -95,6 +131,8 @@ describe(modulePath, () => {
         .to.equal('undefined');
       expect(typeof newSession.reasonForDivorceAdulteryKnowWhen)
         .to.equal('undefined');
+      expect(typeof newSession.reasonForDivorceAdulteryWhenDetails)
+        .to.equal('undefined');
     });
 
     it('it does not remove reasonForDivorceAdulteryKnowWhen if reasonForDivorceAdulteryWishToName is set to Yes', () => {
@@ -110,23 +148,42 @@ describe(modulePath, () => {
       expect(newSession.reasonForDivorceAdulteryWishToName).to.equal('Yes');
       expect(newSession.reasonForDivorceAdulteryKnowWhen)
         .to.equal(previousSession.reasonForDivorceAdulteryKnowWhen);
+      expect(newSession.reasonForDivorceAdulteryWhenDetails)
+        .to.equal(previousSession.reasonForDivorceAdulteryWhenDetails);
+    });
+
+    it('it does not remove reasonForDivorceAdulteryWhenDetails if reasonForDivorceAdulteryKnowWhen is not changed from No', () => {
+      const previousSession = {
+        reasonForDivorceAdulteryKnowWhen: 'Yes',
+        reasonForDivorceAdulteryWhenDetails: 'placeholder'
+      };
+
+      const session = clone(previousSession);
+      session.reasonForDivorceAdulteryKnowWhen = 'No';
+
+      const newSession = removeStaleData(previousSession, session);
+      expect(newSession.reasonForDivorceAdulteryWhenDetails)
+        .to.equal(previousSession.reasonForDivorceAdulteryWhenDetails);
+    });
+
+    it('it does remove reasonForDivorceAdulteryWhenDetails if reasonForDivorceAdulteryKnowWhen is changed from No', () => {
+      const previousSession = {
+        reasonForDivorceAdulteryKnowWhen: 'No',
+        reasonForDivorceAdulteryWhenDetails: 'placeholder'
+      };
+
+      const session = clone(previousSession);
+      session.reasonForDivorceAdulteryKnowWhen = 'Yes';
+
+      const newSession = removeStaleData(previousSession, session);
+      expect(typeof newSession.reasonForDivorceAdulteryWhenDetails)
+        .to.equal('undefined');
     });
   });
 
   describe('Check Your Answers', () => {
-    it('renders the cya template', done => {
-      testCYATemplate(done, underTest);
-    });
-
-    it('renders adultery when details', done => {
-      const contentToExist = [ 'question' ];
-
-      const valuesToExist = ['reasonForDivorceAdulteryKnowWhen'];
-
-      const context = { reasonForDivorceAdulteryKnowWhen: 'Yes' };
-
-      testExistenceCYA(done, underTest, content,
-        contentToExist, valuesToExist, context);
+    it('does not renders the cya template', done => {
+      testDisabledCYATemplate(done, underTest);
     });
   });
 });

--- a/app/steps/grounds-for-divorce/adultery/where/index.js
+++ b/app/steps/grounds-for-divorce/adultery/where/index.js
@@ -23,5 +23,24 @@ module.exports = class AdulteryWhere extends ValidationStep {
         remove('reasonForDivorceAdulteryKnowWhere');
       }
     });
+
+    watch('reasonForDivorceAdulteryKnowWhere', (previousSession, session, remove) => {
+      if (previousSession.reasonForDivorceAdulteryKnowWhere === 'No') {
+        remove('reasonForDivorceAdulteryWhereDetails');
+      }
+    });
+  }
+
+  action(ctx, session) {
+    if (ctx.reasonForDivorceAdulteryKnowWhere === 'No') {
+      session.reasonForDivorceAdulteryWhereDetails = 'The applicant does not know where the adultery took place';
+    }
+
+    return [ctx, session];
+  }
+
+  // disable check your answers
+  get checkYourAnswersTemplate() {
+    return false;
   }
 };

--- a/app/steps/grounds-for-divorce/adultery/where/index.js
+++ b/app/steps/grounds-for-divorce/adultery/where/index.js
@@ -38,9 +38,4 @@ module.exports = class AdulteryWhere extends ValidationStep {
 
     return [ctx, session];
   }
-
-  // disable check your answers
-  get checkYourAnswersTemplate() {
-    return false;
-  }
 };

--- a/app/steps/grounds-for-divorce/adultery/where/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/where/index.test.js
@@ -2,7 +2,7 @@
 const request = require('supertest');
 const {
   testContent, testErrors, testRedirect,
-  testDisabledCYATemplate,
+  testCYATemplate, testExistenceCYA,
   postData, expectSessionValue
 } = require('test/util/assertions');
 const { withSession } = require('test/util/setup');
@@ -154,8 +154,19 @@ describe(modulePath, () => {
   });
 
   describe('Check Your Answers', () => {
-    it('does not render the cya template', done => {
-      testDisabledCYATemplate(done, underTest);
+    it('renders the cya template', done => {
+      testCYATemplate(done, underTest);
+    });
+
+    it('renders adultery where details', done => {
+      const contentToExist = [ 'question' ];
+
+      const valuesToExist = ['reasonForDivorceAdulteryKnowWhere'];
+
+      const context = { reasonForDivorceAdulteryKnowWhere: 'Yes' };
+
+      testExistenceCYA(done, underTest, content,
+        contentToExist, valuesToExist, context);
     });
   });
 });

--- a/test/util/assertions.js
+++ b/test/util/assertions.js
@@ -142,11 +142,6 @@ exports.testNoCYATemplate = (done, underTest) => {
   done();
 };
 
-exports.testDisabledCYATemplate = (done, underTest) => {
-  expect(underTest.checkYourAnswersTemplate).to.equal(false);
-  done();
-};
-
 exports.testExistenceCYA = (done, underTest, content, contentToExist = [], valuesToExist = [], data = {}, session = {}) => {
 
   const checkContentExists = html => {

--- a/test/util/assertions.js
+++ b/test/util/assertions.js
@@ -142,6 +142,11 @@ exports.testNoCYATemplate = (done, underTest) => {
   done();
 };
 
+exports.testDisabledCYATemplate = (done, underTest) => {
+  expect(underTest.checkYourAnswersTemplate).to.equal(false);
+  done();
+};
+
 exports.testExistenceCYA = (done, underTest, content, contentToExist = [], valuesToExist = [], data = {}, session = {}) => {
 
   const checkContentExists = html => {


### PR DESCRIPTION
<!--- Provide a human readable summary of the change in the Title above -->

<!-- Provide a link to the story/task in JIRA -->
<!-- Links in markdown are [description](https://url) -->
[DIV-2252](https://tools.hmcts.net/jira/browse/DIV-2252)

#### What this change does?

<!-- Describe what the change does -->
Previously, when the user selects No to Adultery Know When and Adultery Know Where questions, the details of these would be left empty.
It is a new requirement for there to be default text displayed on the Divorce Mini Petition when those values are set to No.
As the mini petition is a digitally signed document, the user must be made aware of the content, thus we are adding the default statement to the users Check Your Answers page when Know When and Know Where are set to 'No'.

<!-- Focus on the end result of the change, e.g. -->
<!-- -  How does it effect the user? -->
<!-- -  How does it effect the code base? -->
<!-- -  How does it effect Ops? -->

#### Why make this change?

<!-- Describe why we are making this change -->
In order to meet requirements for the mini petition to show Adultery Know When and Adultery Know Where details, without causing a legal issue.

<!-- Focus on the user need or technical requirement -->

#### How is the change implemented?

<!-- Describe the changes themselves -->

The Adultery Know When and Know Where Details are now set to a default string when the user posts the form on the Know When and Know Where pages successfully.
The stale data watch for these two variables is removed from the Adultery Details page so that it won't be wiped on variable change.
Instead, additional stale data watch is added to both Know When and Know Where which when either of those variables is changed, if the previous value is 'No', delete the existing details as they would be the default set. If the previous value is not 'No', then don't do anything. This would mean if the user changes their answer from 'No' to 'Yes', they won't see the default text appear in the text field.
CheckYourAnswers (subject to change) for Know When and Know Where are now not shown at all, as the Details of these two will always be shown now on CYA.

Unit tests have been added for these scenarios.

<!-- Focus on giving a short description of each main change -->
<!-- Point out areas you want special attention given to -->
<!-- Consider linking to the major changes if they need special attention -->
<!-- If you are adding any new libraries, include links to their docs -->
