### PR TITLE
Set email from idam user details

### DIFF
--- a/app/core/ValidationStep.js
+++ b/app/core/ValidationStep.js
@@ -1,28 +1,24 @@
 const { filter, isEqual, map, mapValues, reduce, uniqWith } = require('lodash');
 const Ajv = require('ajv');
 const Step = require('./Step');
-const { protect } = require('app/services/idam');
 const initSession = require('app/middleware/initSession');
 const sessionTimeout = require('app/middleware/sessionTimeout');
 const { hasSubmitted } = require('app/middleware/submissionMiddleware');
 const { restoreFromDraftStore } = require('app/middleware/draftPetitionStoreMiddleware');
-const { features } = require('@hmcts/div-feature-toggle-client')().featureToggles;
+const { idamProtect } = require('app/middleware/idamProtectMiddleware');
+const { setIdamUserDetails } = require('app/middleware/setIdamDetailsToSessionMiddleware');
 const fs = require('fs');
 
 const ajv = new Ajv({ allErrors: true, v5: true });
 
 module.exports = class ValidationStep extends Step {
   get middleware() {
-    const protectCall = protect();
-    const idamProtect = (req, res, next) => {
-      return features.idam ? protectCall(req, res, next) : next();
-    };
-
     return [
       idamProtect,
       initSession,
       sessionTimeout,
       restoreFromDraftStore,
+      setIdamUserDetails,
       hasSubmitted
     ];
   }

--- a/app/middleware/idamProtectMiddleware.js
+++ b/app/middleware/idamProtectMiddleware.js
@@ -1,0 +1,17 @@
+const idam = require('app/services/idam');
+const { features } = require('@hmcts/div-feature-toggle-client')().featureToggles;
+
+function idamProtect(req, res, next) {
+  if (!features.idam) {
+    return next();
+  }
+
+  const middlewareNext = (userDetails = {}) => {
+    req.idam = { userDetails };
+    next();
+  };
+
+  return idam.protect()(req, res, middlewareNext);
+}
+
+module.exports = { idamProtect };

--- a/app/middleware/idamProtectMiddleware.test.js
+++ b/app/middleware/idamProtectMiddleware.test.js
@@ -1,0 +1,57 @@
+const { expect, sinon } = require('test/util/chai');
+const idamMock = require('test/mocks/idam');
+const featureTogglesMock = require('test/mocks/featureToggles');
+const idam = require('app/services/idam');
+
+const modulePath = 'app/middleware/idamProtectMiddleware';
+const underTest = require(modulePath);
+
+let req = {};
+let res = {};
+let next = {};
+let userDetails = {};
+const two = 2;
+
+describe(modulePath, () => {
+  beforeEach(() => {
+    idamMock.stub();
+    featureTogglesMock.stub();
+    req = {};
+    res = {};
+    next = sinon.stub();
+    userDetails = { email: 'email@email.com' };
+    const protectStub = sinon.stub().callsArgWith(two, userDetails);
+    sinon.stub(idam, 'protect').returns(protectStub);
+  });
+
+  afterEach(() => {
+    idamMock.restore();
+    featureTogglesMock.restore();
+    idam.protect.restore();
+  });
+
+  it('with idam disabled it should not attempt to get user details from idam', done => {
+    const test = complete => {
+      underTest.idamProtect(req, res, next);
+      expect(next.calledOnce).to.eql(true);
+      expect(next.calledWith()).to.eql(true);
+      expect(req.hasOwnProperty('idam')).to.eql(false);
+      complete();
+    };
+    const featureMock = featureTogglesMock.when('idam', false, test);
+    featureMock(done);
+  });
+
+  it('with idam enabled it should save the idam userdetails to the req object', done => {
+    const test = complete => {
+      underTest.idamProtect(req, res, next);
+      expect(next.calledOnce).to.eql(true);
+      expect(next.calledWith()).to.eql(true);
+      expect(req.hasOwnProperty('idam')).to.eql(true);
+      expect(req.idam).to.eql({ userDetails });
+      complete();
+    };
+    const featureMock = featureTogglesMock.when('idam', true, test);
+    featureMock(done);
+  });
+});

--- a/app/middleware/setIdamDetailsToSessionMiddleware.js
+++ b/app/middleware/setIdamDetailsToSessionMiddleware.js
@@ -1,0 +1,17 @@
+function setIdamUserDetails(req, res, next) {
+  const hasValidSession = req.session && req.session.hasOwnProperty('expires');
+  const hasIdamUserDetails = req.idam && req.idam.hasOwnProperty('userDetails');
+
+  if (!hasIdamUserDetails || !hasValidSession) {
+    return next();
+  }
+
+  const shouldUpdateEmail = !req.session.petitionerEmail && req.idam.userDetails.email;
+  if (shouldUpdateEmail) {
+    req.session.petitionerEmail = req.idam.email;
+  }
+
+  return next();
+}
+
+module.exports = { setIdamUserDetails };

--- a/app/middleware/setIdamDetailsToSessionMiddleware.test.js
+++ b/app/middleware/setIdamDetailsToSessionMiddleware.test.js
@@ -1,0 +1,70 @@
+const { expect, sinon } = require('test/util/chai');
+
+const modulePath = 'app/middleware/setIdamDetailsToSessionMiddleware';
+const underTest = require(modulePath);
+
+let req = {};
+let res = {};
+let next = {};
+const userDetails = { email: 'email@email.com' };
+const validSession = { expires: 1111 };
+
+describe(modulePath, () => {
+  beforeEach(() => {
+    req = {};
+    res = {};
+    next = sinon.stub();
+  });
+
+  it('returns early if no valid session', () => {
+    req.session = {};
+    req.idam = { userDetails };
+    underTest.setIdamUserDetails(req, res, next);
+
+    expect(next.calledOnce).to.eql(true);
+    expect(req.session).to.eql({});
+  });
+
+  it('returns early if no idam user details', () => {
+    req.session = validSession;
+    underTest.setIdamUserDetails(req, res, next);
+
+    expect(next.calledOnce).to.eql(true);
+    expect(req.session).to.eql(validSession);
+  });
+
+  it('does not update session.petitionerEmail if no email in idam user details', () => {
+    req.session = validSession;
+    req.idam = { name: 'test name' };
+    underTest.setIdamUserDetails(req, res, next);
+
+    expect(next.calledOnce).to.eql(true);
+    expect(req.session).to.eql(validSession);
+  });
+
+  it('does not update session.petitionerEmail if session.email already set', () => {
+    const sessionWithEmailAlreadySet = Object.assign(
+      { petitionerEmail: 'emailAreadySet@email.com' },
+      validSession
+    );
+    req.session = sessionWithEmailAlreadySet;
+    req.idam = { userDetails };
+    underTest.setIdamUserDetails(req, res, next);
+
+    expect(next.calledOnce).to.eql(true);
+    expect(req.session).to.eql(sessionWithEmailAlreadySet);
+  });
+
+  it('sets the session.petitionerEmail with email returned from idam', () => {
+    req.session = validSession;
+    req.idam = { userDetails };
+    underTest.setIdamUserDetails(req, res, next);
+
+    const sessionShouldBe = Object.assign(
+      { petitionerEmail: userDetails.email },
+      validSession
+    );
+    expect(next.calledOnce).to.eql(true);
+    expect(req.session).to.eql(sessionShouldBe);
+  });
+});

--- a/app/steps/marriage/upload/index.js
+++ b/app/steps/marriage/upload/index.js
@@ -15,9 +15,10 @@ module.exports = class UploadMarriageCertificate extends ValidationStep {
   }
 
   get middleware() {
-    const middleware = super.middleware;
-    middleware.push(evidenceManagmentMiddleware.createHandler('marriageCertificateFiles'));
-    return middleware;
+    return [
+      ...super.middleware,
+      evidenceManagmentMiddleware.createHandler('marriageCertificateFiles')
+    ];
   }
 
   handler(req, res) {

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -102,16 +102,6 @@ describe(modulePath, () => {
     });
 
     context('Online submission is turned ON', () => {
-      it('returns bad request on incorrect request format', done => {
-        // Act.
-        const featureMock = featureTogglesMock
-          .when('onlineSubmission', true, testCustom, agent, underTest, ['empty'], response => {
-            // Assert.
-            expect(response.status).to.equal(statusCodes.BAD_REQUEST);
-          }, 'post');
-        featureMock(done);
-      });
-
       it('gets a service token before calling the payment service', done => {
         // Act.
         const featureMock = featureTogglesMock

--- a/app/steps/submit/index.js
+++ b/app/steps/submit/index.js
@@ -1,18 +1,23 @@
 const statusCodes = require('http-status-codes');
 const logger = require('@hmcts/nodejs-logging').getLogger(__filename);
-
+const initSession = require('app/middleware/initSession');
+const sessionTimeout = require('app/middleware/sessionTimeout');
+const { restoreFromDraftStore } = require('app/middleware/draftPetitionStoreMiddleware');
+const { idamProtect } = require('app/middleware/idamProtectMiddleware');
+const { setIdamUserDetails } = require('app/middleware/setIdamDetailsToSessionMiddleware');
 const Step = require('app/core/Step');
-const { protect } = require('app/services/idam');
 const { features } = require('@hmcts/div-feature-toggle-client')().featureToggles;
 const submissionService = require('app/services/submission');
 
 module.exports = class Submit extends Step {
   get middleware() {
-    const idamProtect = (req, res, next) => {
-      return features.idam ? protect()(req, res, next) : next();
-    };
-
-    return [idamProtect];
+    return [
+      idamProtect,
+      initSession,
+      sessionTimeout,
+      restoreFromDraftStore,
+      setIdamUserDetails
+    ];
   }
 
   handler(req, res) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@hmcts/div-feature-toggle-client": "https://github.com/hmcts/div-feature-toggle-client#1.0.7",
-    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#4.0.0",
+    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#5.0.0",
     "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#4.0.4",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#2.1.4",
     "@hmcts/nodejs-healthcheck": "^1.2.0",

--- a/test/util/assertions.js
+++ b/test/util/assertions.js
@@ -380,7 +380,7 @@ exports.testCustom = (done, agent, underTest, cookies = [], callback, method = '
     let request = agent[method](underTest.url);
 
     if (cookies.length) {
-      request = request.set('Cookie', cookies);
+      request = request.set('Cookie', [request.cookies, ...cookies]);
     }
 
     return request

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@
     request-promise-native "^1.0.5"
     uuid "^3.1.0"
 
-"@hmcts/div-idam-express-middleware@https://github.com/hmcts/div-idam-express-middleware#4.0.0":
-  version "4.0.0"
-  resolved "https://github.com/hmcts/div-idam-express-middleware#5e02f8881df2e6ca94028dd2d99c978e8ff297f8"
+"@hmcts/div-idam-express-middleware@https://github.com/hmcts/div-idam-express-middleware#5.0.0":
+  version "5.0.0"
+  resolved "https://github.com/hmcts/div-idam-express-middleware#4c6503902be1c7fe7bfdb81317175105c0733785"
   dependencies:
     "@hmcts/nodejs-logging" "^2.2.0"
     request "^2.83.0"


### PR DESCRIPTION
[DIV-2110 - Save and Resume: email address not displayed after save if draft previously deleted](https://tools.hmcts.net/jira/browse/DIV-2110)
[DIV-1795 - SECURITY: /pay/online page is not behind IDAM](https://tools.hmcts.net/jira/browse/DIV-1795)

#### What this change does?
 - Refactors idam protect to return userDetails
 - Adds new middleware to handle setting idam email to session
 - Ensures all pages are using correct middleware ( i.e. idam protect, session, etc ... )