### PR TITLE
Div 1956 invalid case ref hitting gov pay

### DIFF
--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -76,6 +76,7 @@ module.exports = class PayOnline extends Step {
     const siteId = get(req.session, `court.${req.session.courts}.siteId`);
 
     if (!caseId) {
+      // console.log('Case Reference is missing');
       logger.error('Case Reference is missing');
       res.redirect('/generic-error');
     }

--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -86,7 +86,7 @@ module.exports = class PayOnline extends Step {
 
     if (!caseId) {
       logger.error('Case ID is missing');
-      res.redirect('/generic-error');
+      return res.redirect('/generic-error');
     }
 
     // Initialise services.

--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -76,8 +76,7 @@ module.exports = class PayOnline extends Step {
     const siteId = get(req.session, `court.${req.session.courts}.siteId`);
 
     if (!caseId) {
-      // console.log('Case Reference is missing');
-      logger.error('Case Reference is missing');
+      logger.error('Case ID is missing');
       res.redirect('/generic-error');
     }
 

--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -75,6 +75,11 @@ module.exports = class PayOnline extends Step {
     const caseId = req.session.caseId;
     const siteId = get(req.session, `court.${req.session.courts}.siteId`);
 
+    if (!caseId) {
+      logger.error('Case Reference is missing');
+      res.redirect('/generic-error');
+    }
+
     // Initialise services.
     const serviceToken = serviceTokenService.setup();
     const payment = paymentService.setup();

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -206,10 +206,23 @@ describe(modulePath, () => {
         it('redirects to the gov.uk payment page', done => {
           // Act.
           const featureMock = featureTogglesMock
-            .when('onlineSubmission', true, testCustom, agent, underTest, cookies, response => {
+            .when('onlineSubmission', true, testCustom, agent, underTest, [], response => {
               // Assert.
               expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
               expect(response.header.location).to.equal('https://pay.the.gov/here');
+            }, 'post');
+          featureMock(done);
+        });
+      });
+
+      context('Case Id is missing', () => {
+        it('redirects to the generic error page', done => {
+          // Act.
+          const featureMock = featureTogglesMock
+            .when('onlineSubmission', true, testCustom, agent, underTest, cookies, response => {
+              // Assert.
+              expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
+              expect(response.header.location).to.equal('/generic-error');
             }, 'post');
           featureMock(done);
         });

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -194,7 +194,7 @@ describe(modulePath, () => {
         it('updates CCD with payment data', done => {
           // Act.
           const featureMock = featureTogglesMock
-            .when('onlineSubmission', true, testCustom, agent, underTest, cookies, () => {
+            .when('onlineSubmission', true, testCustom, agent, underTest, [], () => {
               // Assert.
               expect(update.calledOnce).to.equal(true);
             }, 'post');

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -177,6 +177,22 @@ describe(modulePath, () => {
       });
 
       context('payment creation was successful', () => {
+        let session = {}, siteId = '';
+
+        beforeEach(done => {
+          siteId = 'some-code';
+          session = {
+            caseId: 'some-case-id',
+            court: {
+              someCourt: { siteId },
+              someOtherCourt: { siteId: 'some-other-code' }
+            },
+            courts: 'someCourt'
+          };
+
+          withSession(done, agent, session);
+        });
+
         it('updates CCD with payment data', done => {
           // Act.
           const featureMock = featureTogglesMock

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -194,7 +194,7 @@ describe(modulePath, () => {
         it('updates CCD with payment data', done => {
           // Act.
           const featureMock = featureTogglesMock
-            .when('onlineSubmission', true, testCustom, agent, underTest, [], () => {
+            .when('onlineSubmission', true, testCustom, agent, underTest, cookies, () => {
               // Assert.
               expect(update.calledOnce).to.equal(true);
             }, 'post');
@@ -204,7 +204,7 @@ describe(modulePath, () => {
         it('redirects to the gov.uk payment page', done => {
           // Act.
           const featureMock = featureTogglesMock
-            .when('onlineSubmission', true, testCustom, agent, underTest, [], response => {
+            .when('onlineSubmission', true, testCustom, agent, underTest, cookies, response => {
               // Assert.
               expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
               expect(response.header.location).to.equal('https://pay.the.gov/here');

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -107,11 +107,54 @@ describe(modulePath, () => {
       });
     });
 
+    context('Case Id is missing', () => {
+      let session = {}, siteId = '';
+
+      beforeEach(done => {
+        siteId = 'some-code';
+        session = {
+          court: {
+            someCourt: { siteId },
+            someOtherCourt: { siteId: 'some-other-code' }
+          },
+          courts: 'someCourt'
+        };
+
+        withSession(done, agent, session);
+      });
+      it('redirects to the generic error page', done => {
+        // Act.
+        const featureMock = featureTogglesMock
+          .when('onlineSubmission', true, testCustom, agent, underTest, cookies, response => {
+            // Assert.
+            expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
+            expect(response.header.location).to.equal('/generic-error');
+          }, 'post');
+        featureMock(done);
+      });
+    });
+
     context('Online submission is turned ON', () => {
+      let session = {}, siteId = '';
+
+      beforeEach(done => {
+        siteId = 'some-code';
+        session = {
+          caseId: 'some-case-id',
+          court: {
+            someCourt: { siteId },
+            someOtherCourt: { siteId: 'some-other-code' }
+          },
+          courts: 'someCourt'
+        };
+
+        withSession(done, agent, session);
+      });
+
       it('gets a service token before calling the payment service', done => {
         // Act.
         const featureMock = featureTogglesMock
-          .when('onlineSubmission', true, testCustom, agent, underTest, [], () => {
+          .when('onlineSubmission', true, testCustom, agent, underTest, cookies, () => {
             // Assert.
             expect(getToken.calledBefore(create)).to.equal(true);
           }, 'post');
@@ -119,22 +162,6 @@ describe(modulePath, () => {
       });
 
       context('Court is selected', () => {
-        let session = {}, siteId = '';
-
-        beforeEach(done => {
-          siteId = 'some-code';
-          session = {
-            caseId: 'some-case-id',
-            court: {
-              someCourt: { siteId },
-              someOtherCourt: { siteId: 'some-other-code' }
-            },
-            courts: 'someCourt'
-          };
-
-          withSession(done, agent, session);
-        });
-
         it('creates payment with the site ID of the court', done => {
           // Act.
           const featureMock = featureTogglesMock
@@ -175,22 +202,6 @@ describe(modulePath, () => {
       });
 
       context('payment creation was successful', () => {
-        let session = {}, siteId = '';
-
-        beforeEach(done => {
-          siteId = 'some-code';
-          session = {
-            caseId: 'some-case-id',
-            court: {
-              someCourt: { siteId },
-              someOtherCourt: { siteId: 'some-other-code' }
-            },
-            courts: 'someCourt'
-          };
-
-          withSession(done, agent, session);
-        });
-
         it('updates CCD with payment data', done => {
           // Act.
           const featureMock = featureTogglesMock
@@ -208,19 +219,6 @@ describe(modulePath, () => {
               // Assert.
               expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
               expect(response.header.location).to.equal('https://pay.the.gov/here');
-            }, 'post');
-          featureMock(done);
-        });
-      });
-
-      context('Case Id is missing', () => {
-        it('redirects to the generic error page', done => {
-          // Act.
-          const featureMock = featureTogglesMock
-            .when('onlineSubmission', true, testCustom, agent, underTest, cookies, response => {
-              // Assert.
-              expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
-              expect(response.header.location).to.equal('/generic-error');
             }, 'post');
           featureMock(done);
         });

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -129,6 +129,7 @@ describe(modulePath, () => {
             // Assert.
             expect(response.status).to.equal(statusCodes.MOVED_TEMPORARILY);
             expect(response.header.location).to.equal('/generic-error');
+            expect(serviceToken.setup.called).to.eql(false);
           }, 'post');
         featureMock(done);
       });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@hmcts/div-feature-toggle-client": "https://github.com/hmcts/div-feature-toggle-client#1.0.7",
     "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#4.0.0",
-    "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#4.0.4",
+    "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#5.0.0",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#2.1.4",
     "@hmcts/nodejs-healthcheck": "^1.2.0",
     "@hmcts/nodejs-logging": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,13 +36,13 @@
     request "^2.81.0"
     request-promise-native "^1.0.4"
 
-"@hmcts/div-pay-client@https://github.com/hmcts/div-pay-client#4.0.4":
-  version "4.0.4"
-  resolved "https://github.com/hmcts/div-pay-client#be1555624bea9d40fd993811d774b9f39d25b7f0"
+"@hmcts/div-pay-client@https://github.com/hmcts/div-pay-client#5.0.0":
+  version "5.0.0"
+  resolved "https://github.com/hmcts/div-pay-client#dc10801e411cbce41e39beb099a0dde6386f8e4b"
   dependencies:
+    "@hmcts/nodejs-logging" "^1.4.2"
     request "^2.81.0"
     request-promise-native "^1.0.5"
-    uuid "^3.1.0"
 
 "@hmcts/div-service-auth-provider-client@https://github.com/hmcts/div-service-auth-provider-client#2.1.4":
   version "2.1.4"


### PR DESCRIPTION
Throwing an error when Case ID is not provided.

https://tools.hmcts.net/jira/browse/DIV-1956


Promise rejects when case ID/reference is not provided
Error is logged in this scenario as well
Unit tests updated to cover this scenario
This will prevent payments with invalid case ID being forwarded to prod Gov Pay subsequently
