### PR TITLE
correct email reference and remove old set email code

### DIFF
--- a/app/middleware/setIdamDetailsToSessionMiddleware.js
+++ b/app/middleware/setIdamDetailsToSessionMiddleware.js
@@ -8,7 +8,7 @@ function setIdamUserDetails(req, res, next) {
 
   const shouldUpdateEmail = !req.session.petitionerEmail && req.idam.userDetails.email;
   if (shouldUpdateEmail) {
-    req.session.petitionerEmail = req.idam.email;
+    req.session.petitionerEmail = req.idam.userDetails.email;
   }
 
   return next();

--- a/app/steps/authenticated/index.js
+++ b/app/steps/authenticated/index.js
@@ -7,13 +7,7 @@ const sessionTimeout = require('app/middleware/sessionTimeout');
 const idamLandingPage = (req, res, next) => {
   if (features.idam) {
     const landing = idam.landingPage();
-    return landing(req, res, userDetails => {
-      // save the user email to the session if its not already set
-      if (!req.session.petitionerEmail) {
-        req.session.petitionerEmail = userDetails.email;
-      }
-      next();
-    });
+    return landing(req, res, next);
   }
 
   return next();

--- a/app/steps/authenticated/index.test.js
+++ b/app/steps/authenticated/index.test.js
@@ -13,12 +13,11 @@ let s = {};
 let agent = {};
 let underTest = {};
 let landingPageStub = {};
-const idamUserDetails = { email: 'simulate-delivered@notifications.service.gov.uk' };
 const two = 2;
 
 describe(modulePath, () => {
   beforeEach(() => {
-    landingPageStub = sinon.stub().callsArgWith(two, idamUserDetails);
+    landingPageStub = sinon.stub().callsArgWith(two);
     sinon.stub(idam, 'landingPage').returns(landingPageStub);
     idamMock.stub();
     s = server.init();
@@ -46,7 +45,7 @@ describe(modulePath, () => {
   });
 
   describe('idam on', () => {
-    it('sets the email address returned from the idam user', done => {
+    it('redirects to the landing page', done => {
       const context = {};
 
       const featureMock = featureTogglesMock
@@ -54,8 +53,7 @@ describe(modulePath, () => {
 
       featureMock(() => {
         getSession(agent)
-          .then(session => {
-            expect(session.petitionerEmail).to.eql(idamUserDetails.email);
+          .then(() => {
             expect(landingPageStub.calledOnce).to.eql(true);
           })
           .then(done, done);


### PR DESCRIPTION
[DIV-2110 - Save and Resume: email address not displayed after save if draft previously deleted](https://tools.hmcts.net/jira/browse/DIV-2110)

#### What this change does?
 - Corrects incorrect reference to email from idam
 - Removes stale code for setting email on idam login