### PR TITLE
Fix for e2e feature toggle request not resolving properly

### DIFF
--- a/test/end-to-end/helpers/featureToggleHelper.js
+++ b/test/end-to-end/helpers/featureToggleHelper.js
@@ -10,10 +10,10 @@ let toggleStore = require('test/end-to-end/helpers/featureToggleStore.js');
 
 class FeatureToggleHelper extends Helper {
 
-  _init() {
+  _beforeSuite() {
     const toggle = 'idam';
 
-    this.getFeatureEnabled(toggle).then((res) => {
+    return this.getFeatureEnabled(toggle).then((res) => {
       console.log(`Feature idam is ${res ? 'enabled' : 'disabled'}`); // eslint-disable-line
       toggleStore.setToggle(toggle, res);
     });


### PR DESCRIPTION
# Description

This change fixes the feature toggle helper so that promises are correctly added to Codecept promise queue for e2e tests to use. Uses `_beforeSuite()` hook.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Have tested locally with @tchow8 to prove that the original situation where feature toggle results were resolving AFTER tests had already started no longer occurs. Have also run tests against DevA to see that promises still resolve properly.


**Test Configuration**:

* Hardware: Dell
* O/S and version: Linux
* JDK: n/a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
