### PR TITLE
DIV- Accessibility -Duplicate ID’s- reason-for-divorce/adultery/details pages

### DIFF
--- a/app/steps/grounds-for-divorce/adultery/details/template.html
+++ b/app/steps/grounds-for-divorce/adultery/details/template.html
@@ -13,24 +13,20 @@
     </div>
 
     {% if (fields.reasonForDivorceAdulteryKnowWhen.value === "Yes") %}
-        <div id="reasonForDivorceAdulteryWhenDetails">
         {{ textArea(
             name='reasonForDivorceAdulteryWhenDetails',
             field=fields.reasonForDivorceAdulteryWhenDetails,
             label=content.whenDidAdulteryHappen
         ) }}
-        </div>
 
     {% endif %}
 
     {% if (fields.reasonForDivorceAdulteryKnowWhere.value === "Yes") %}
-        <div id="reasonForDivorceAdulteryWhereDetails">
         {{ textArea(
             name='reasonForDivorceAdulteryWhereDetails',
             field=fields.reasonForDivorceAdulteryWhereDetails,
             label=content.whereDidAdulteryHappen
         ) }}
-        </div>
     {% endif %}
 
     {% if (fields.reasonForDivorceAdulteryKnowWhen.value === "No" and fields.reasonForDivorceAdulteryKnowWhere.value === "No") %}


### PR DESCRIPTION
# Description

Removed `div`s that were wrapped around text areas in the `reason-for-divorce/adultery/details` page because the had the same id as the text area itself. 

Fixes # DIV-[2271 DIV- Accessibility -Duplicate ID’s- reason-for-divorce/adultery/details pages](https://tools.hmcts.net/jira/browse/DIV-2271)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the new version and made sure it looks the same as the previous version of the code.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
