### PR TITLE
CNP codecept proxy change

### DIFF
--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -15,7 +15,8 @@ exports.config = {
       'waitForAction': waitForAction,
       'show': false,
       'switches': {
-        'ignore-certificate-errors': true
+        'ignore-certificate-errors': true,
+        'proxy-server': process.env.E2E_PROXY_SERVER || ''
       }
     },
     'FeatureToggleHelper': {


### PR DESCRIPTION
# Description

This change adds nightmarejs `proxy-server` option to codecept.conf.js for running e2e tests locally. To use locally, set `E2E_PROXY_SERVER` env var.

Fixes # ability to run e2e tests locally through a proxy.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally both with and without `E2E_PROXY_SERVER` being set, as well as via a Jenkins job again both with and without the env var being set.


**Test Configuration**:

* Hardware: Jenkins + local

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
