### PR TITLE
Remove use of IDAM JWT token to get user id

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -4,7 +4,6 @@
 		"https://nodesecurity.io/advisories/534",
 		"https://nodesecurity.io/advisories/533",
 		"https://nodesecurity.io/advisories/577",
-		"https://nodesecurity.io/advisories/157",
-    "https://nodesecurity.io/advisories/654"
+		"https://nodesecurity.io/advisories/157"
   ]
 }

--- a/.nsprc
+++ b/.nsprc
@@ -4,6 +4,7 @@
 		"https://nodesecurity.io/advisories/534",
 		"https://nodesecurity.io/advisories/533",
 		"https://nodesecurity.io/advisories/577",
-		"https://nodesecurity.io/advisories/157"
+		"https://nodesecurity.io/advisories/157",
+    "https://nodesecurity.io/advisories/654"
   ]
 }

--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ const i18nTemplate = require('app/core/utils/i18nTemplate')({
 const statusCode = require('app/core/utils/statusCode');
 const logging = require('@hmcts/nodejs-logging');
 const events = require('events');
+const idam = require('app/services/idam');
 
 // Prevent node warnings re: MaxListenersExceededWarning
 events.EventEmitter.defaultMaxListeners = Infinity;
@@ -118,6 +119,9 @@ exports.init = () => {
   // Support for parsing data in POSTs
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
+
+  // Get user details from idam, sets req.idam.userDetails
+  app.use(idam.userDetails());
 
   app.set('trust proxy', 1);
   app.use(sessions.prod());

--- a/app/middleware/idamProtectMiddleware.js
+++ b/app/middleware/idamProtectMiddleware.js
@@ -6,12 +6,7 @@ function idamProtect(req, res, next) {
     return next();
   }
 
-  const middlewareNext = (userDetails = {}) => {
-    req.idam = { userDetails };
-    next();
-  };
-
-  return idam.protect()(req, res, middlewareNext);
+  return idam.protect()(req, res, next);
 }
 
 module.exports = { idamProtect };

--- a/app/middleware/idamProtectMiddleware.test.js
+++ b/app/middleware/idamProtectMiddleware.test.js
@@ -30,25 +30,25 @@ describe(modulePath, () => {
     idam.protect.restore();
   });
 
-  it('with idam disabled it should not attempt to get user details from idam', done => {
+  it('with idam disabled it should call next', done => {
     const test = complete => {
       underTest.idamProtect(req, res, next);
       expect(next.calledOnce).to.eql(true);
       expect(next.calledWith()).to.eql(true);
-      expect(req.hasOwnProperty('idam')).to.eql(false);
+      expect(idam.protect.calledOnce).to.eql(false);
+      expect(idam.protect.calledWith()).to.eql(false);
       complete();
     };
     const featureMock = featureTogglesMock.when('idam', false, test);
     featureMock(done);
   });
 
-  it('with idam enabled it should save the idam userdetails to the req object', done => {
+  it('with idam enabled it should call idam.protect', done => {
     const test = complete => {
       underTest.idamProtect(req, res, next);
       expect(next.calledOnce).to.eql(true);
       expect(next.calledWith()).to.eql(true);
-      expect(req.hasOwnProperty('idam')).to.eql(true);
-      expect(req.idam).to.eql({ userDetails });
+      expect(idam.protect.calledOnce).to.eql(true);
       complete();
     };
     const featureMock = featureTogglesMock.when('idam', true, test);

--- a/app/middleware/setIdamDetailsToSessionMiddleware.js
+++ b/app/middleware/setIdamDetailsToSessionMiddleware.js
@@ -1,8 +1,9 @@
+const idam = require('app/services/idam');
+
 function setIdamUserDetails(req, res, next) {
   const hasValidSession = req.session && req.session.hasOwnProperty('expires');
-  const hasIdamUserDetails = req.idam && req.idam.hasOwnProperty('userDetails');
 
-  if (!hasIdamUserDetails || !hasValidSession) {
+  if (!idam.userId(req) || !hasValidSession) {
     return next();
   }
 

--- a/app/middleware/setIdamDetailsToSessionMiddleware.test.js
+++ b/app/middleware/setIdamDetailsToSessionMiddleware.test.js
@@ -6,7 +6,10 @@ const underTest = require(modulePath);
 let req = {};
 let res = {};
 let next = {};
-const userDetails = { email: 'email@email.com' };
+const userDetails = {
+  email: 'email@email.com',
+  id: 'user.id'
+};
 const validSession = { expires: 1111 };
 
 describe(modulePath, () => {

--- a/app/services/idam.js
+++ b/app/services/idam.js
@@ -35,6 +35,16 @@ module.exports = {
   },
   logout: () => {
     return idamExpressMiddleware.logout(idamArgs);
+  },
+  userDetails: () => {
+    return idamExpressMiddleware.userDetails(idamArgs);
+  },
+  userId: req => {
+    const hasIdamUserDetails = req && req.hasOwnProperty('idam') && req.idam.hasOwnProperty('userDetails');
+    if (hasIdamUserDetails && req.idam.userDetails.id) {
+      return req.idam.userDetails.id;
+    }
+    return undefined; // eslint-disable-line no-undefined
   }
 
 };

--- a/app/services/idam.test.js
+++ b/app/services/idam.test.js
@@ -1,0 +1,22 @@
+const { expect } = require('test/util/chai');
+
+const modulePath = 'app/services/idam';
+const idam = require(modulePath);
+
+let req = {};
+
+describe(modulePath, () => {
+  describe('#userId', () => {
+    it('returns undefined if no userDetails exists', () => {
+      req = {};
+      const userId = idam.userId(req);
+      expect(userId).to.eql(undefined); // eslint-disable-line no-undefined
+    });
+    it('returns user id if userDetails exists', () => {
+      const uid = 'user.id';
+      req.idam = { userDetails: { id: uid } };
+      const userId = idam.userId(req);
+      expect(userId).to.eql(uid);
+    });
+  });
+});

--- a/app/services/sessionSerializer.js
+++ b/app/services/sessionSerializer.js
@@ -1,7 +1,7 @@
 const CONF = require('config');
 const crypto = require('crypto');
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
-const jwt = require('jsonwebtoken');
+const idam = require('app/services/idam');
 
 const sessionEncryptionSecret = CONF.sessionEncryptionSecret;
 const algorithm = 'AES-256-CBC';
@@ -51,20 +51,11 @@ const decryptData = (encryptedData, passwordHash) => {
   }
 };
 
-const createSerializer = (req, res) => {
-  const authToken = req.cookies && req.cookies['__auth-token'] ? req.cookies['__auth-token'] : false;
+const createSerializer = req => {
   let passwordHash = false;
 
-  // Create password using application secret and idamUserId
-  if (authToken) {
-    let idamUserId = null;
-    try {
-      idamUserId = jwt.decode(authToken).id;
-    } catch (error) {
-      res.clearCookie('__auth-token');
-      throw error;
-    }
-
+  const idamUserId = idam.userId(req);
+  if (idamUserId) {
     passwordHash = crypto.createHash('md5')
       .update(sessionEncryptionSecret + idamUserId, 'utf-8')
       .digest('hex')

--- a/app/steps/authenticated/index.js
+++ b/app/steps/authenticated/index.js
@@ -7,9 +7,7 @@ const sessionTimeout = require('app/middleware/sessionTimeout');
 const idamLandingPage = (req, res, next) => {
   if (features.idam) {
     const landing = idam.landingPage();
-    return landing(req, res, () => {
-      next();
-    });
+    return landing(req, res, next);
   }
 
   return next();

--- a/app/steps/pay/pay-online-only/index.js
+++ b/app/steps/pay/pay-online-only/index.js
@@ -12,8 +12,7 @@ const { idamProtect } = require('app/middleware/idamProtectMiddleware');
 const { setIdamUserDetails } = require('app/middleware/setIdamDetailsToSessionMiddleware');
 const { saveSessionToDraftStoreAndClose } = require('app/middleware/draftPetitionStoreMiddleware');
 const requestHandler = require('app/core/helpers/parseRequest');
-
-const jwt = require('jsonwebtoken');
+const idam = require('app/services/idam');
 const CONF = require('config');
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 const get = require('lodash/get');
@@ -61,8 +60,15 @@ module.exports = class PayOnline extends Step {
 
     if (features.idam) {
       authToken = cookies['__auth-token'];
+
+      const idamUserId = idam.userId(req);
+      if (!idamUserId) {
+        logger.error('User does not have any idam userDetails');
+        return res.redirect('/generic-error');
+      }
+
       user = {
-        id: jwt.decode(authToken).id,
+        id: idamUserId,
         bearerToken: authToken
       };
     }

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -9,11 +9,11 @@ const getBaseUrl = require('app/core/utils/baseUrl');
 const { expect, sinon } = require('test/util/chai');
 const statusCodes = require('http-status-codes');
 const { withSession } = require('test/util/setup');
-const jwt = require('jsonwebtoken');
 const serviceToken = require('app/services/serviceToken');
 const payment = require('app/services/payment');
 const submission = require('app/services/submission');
 const CONF = require('config');
+const idam = require('app/services/idam');
 
 const modulePath = 'app/steps/pay/pay-online-only';
 
@@ -29,12 +29,21 @@ const version = CONF.commonProps.applicationFee.version;
 const amount = parseInt(
   CONF.commonProps.applicationFee.fee_amount
 );
+const userDetails = {
+  id: 1,
+  email: 'email@email.com'
+};
+const idamUserDetailsMiddlewareMock = (req, res, next) => {
+  req.idam = { userDetails };
+  next();
+};
 
 describe(modulePath, () => {
   beforeEach(() => {
     sinon.stub(applicationFeeMiddleware, 'updateApplicationFeeMiddleware')
       .callsArgWith(two);
     sinon.spy(getBaseUrl);
+    sinon.stub(idam, 'userDetails').returns(idamUserDetailsMiddlewareMock);
     featureTogglesMock.stub();
     idamMock.stub();
     s = server.init();
@@ -47,6 +56,7 @@ describe(modulePath, () => {
     idamMock.restore();
     featureTogglesMock.restore();
     applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
+    idam.userDetails.restore();
   });
 
   describe('#middleware', () => {
@@ -90,11 +100,9 @@ describe(modulePath, () => {
       sinon.stub(serviceToken, 'setup').returns({ getToken });
       sinon.stub(payment, 'setup').returns({ create });
       sinon.stub(submission, 'setup').returns({ update });
-      sinon.stub(jwt, 'decode').returns({ id: 1 });
     });
 
     afterEach(() => {
-      jwt.decode.restore();
       submission.setup.restore();
       payment.setup.restore();
       serviceToken.setup.restore();

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "connect-redis": "3.1.0",
     "cookie-parser": "^1.4.3",
     "copy-webpack-plugin": "^4.0.1",
-    "css-loader": "^0.27.2",
+    "css-loader": "^0.28.11",
     "csurf": "^1.9.0",
     "dotenv": "^5.0.0",
     "dropzone": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@hmcts/div-feature-toggle-client": "https://github.com/hmcts/div-feature-toggle-client#1.0.7",
-    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#5.0.0",
+    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#6.0.0",
     "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#6.0.0",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#2.1.4",
     "@hmcts/nodejs-healthcheck": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@
     request-promise-native "^1.0.5"
     uuid "^3.1.0"
 
-"@hmcts/div-idam-express-middleware@https://github.com/hmcts/div-idam-express-middleware#5.0.0":
-  version "5.0.0"
-  resolved "https://github.com/hmcts/div-idam-express-middleware#4c6503902be1c7fe7bfdb81317175105c0733785"
+"@hmcts/div-idam-express-middleware@https://github.com/hmcts/div-idam-express-middleware#6.0.0":
+  version "6.0.0"
+  resolved "https://github.com/hmcts/div-idam-express-middleware#3b2466873627729a157b5c831217ff9610ed969d"
   dependencies:
     "@hmcts/nodejs-logging" "^2.2.0"
     request "^2.83.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,7 +520,7 @@ axios@^0.15.3:
   dependencies:
     follow-redirects "1.0.0"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -1529,22 +1529,24 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-loader@^0.27.2:
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.27.3.tgz#69ab6f47b69bfb1b5acee61bac2aab14302ff0dc"
+css-loader@^0.28.11:
+  version "0.28.11"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.11.tgz#c3f9864a700be2711bb5a2462b2389b1a392dab7"
   dependencies:
-    babel-code-frame "^6.11.0"
+    babel-code-frame "^6.26.0"
     css-selector-tokenizer "^0.7.0"
-    cssnano ">=2.6.1 <4"
+    cssnano "^3.10.0"
+    icss-utils "^2.1.0"
     loader-utils "^1.0.2"
     lodash.camelcase "^4.3.0"
-    object-assign "^4.0.1"
+    object-assign "^4.1.1"
     postcss "^5.0.6"
-    postcss-modules-extract-imports "^1.0.0"
-    postcss-modules-local-by-default "^1.0.1"
-    postcss-modules-scope "^1.0.0"
-    postcss-modules-values "^1.1.0"
-    source-list-map "^0.1.7"
+    postcss-modules-extract-imports "^1.2.0"
+    postcss-modules-local-by-default "^1.2.0"
+    postcss-modules-scope "^1.1.0"
+    postcss-modules-values "^1.3.0"
+    postcss-value-parser "^3.3.0"
+    source-list-map "^2.0.0"
 
 css-loader@^0.9.1:
   version "0.9.1"
@@ -1598,7 +1600,7 @@ cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
 
-"cssnano@>=2.6.1 <4":
+cssnano@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
   dependencies:
@@ -3652,6 +3654,12 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
+
+icss-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-2.1.0.tgz#83f0a0ec378bf3246178b6c2ad9136f135b1c962"
+  dependencies:
+    postcss "^6.0.1"
 
 ieee754@^1.1.4:
   version "1.1.11"
@@ -6008,27 +6016,27 @@ postcss-minify-selectors@^2.0.4:
     postcss "^5.0.14"
     postcss-selector-parser "^2.0.0"
 
-postcss-modules-extract-imports@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz#b614c9720be6816eaee35fb3a5faa1dba6a05ddb"
+postcss-modules-extract-imports@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz#66140ecece38ef06bf0d3e355d69bf59d141ea85"
   dependencies:
     postcss "^6.0.1"
 
-postcss-modules-local-by-default@^1.0.1:
+postcss-modules-local-by-default@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
   dependencies:
     css-selector-tokenizer "^0.7.0"
     postcss "^6.0.1"
 
-postcss-modules-scope@^1.0.0:
+postcss-modules-scope@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz#d6ea64994c79f97b62a72b426fbe6056a194bb90"
   dependencies:
     css-selector-tokenizer "^0.7.0"
     postcss "^6.0.1"
 
-postcss-modules-values@^1.1.0:
+postcss-modules-values@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
   dependencies:
@@ -7243,13 +7251,13 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^0.1.7, source-list-map@~0.1.7:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
-
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-list-map@~0.1.7:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
 source-map-resolve@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
# Description

[DIV-2454 - Change how we parse and extract data from the tactical iDAM JWT token - front-end](https://tools.hmcts.net/jira/browse/DIV-2454)

To enable us to remove JWT token parsing on the frontend we need to be able to get idam details earlier in the middleware stack without redirecting use if call fails. This PR adds new functionality that:
1. Uses the updated `div-idam-express-middleware`
2. Gets idam user details earlier in middleware stack and sets to req.idam
3. changes all references to idam JWT token to use `req.idam.userDetails`

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Manually, unit/e2e tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
