### PR TITLE
Div 2466 form elements must have labels

### DIFF
--- a/app/steps/marriage/foreign-certificate/content.json
+++ b/app/steps/marriage/foreign-certificate/content.json
@@ -10,7 +10,8 @@
           "countryName": "Enter the country name",
           "placeOfMarriageTranslation": "How is the place of marriage displayed on the translation of your marriage certificate?",
           "placeOfMarriage": "How is the place of marriage displayed on your marriage certificate?",
-          "wordsOfTranslation": "Copy the words on the translation of your marriage certificate exactly"
+          "wordsOfTranslation": "Copy the words on the translation of your marriage certificate exactly",
+          "copyPlaceOfMarriage": "Copy the place of marriage exactly"
         },
 
         "checkYourAnswersContent": {

--- a/app/steps/marriage/foreign-certificate/content.json
+++ b/app/steps/marriage/foreign-certificate/content.json
@@ -11,7 +11,7 @@
           "placeOfMarriageTranslation": "How is the place of marriage displayed on the translation of your marriage certificate?",
           "placeOfMarriage": "How is the place of marriage displayed on your marriage certificate?",
           "wordsOfTranslation": "Copy the words on the translation of your marriage certificate exactly",
-          "copyPlaceOfMarriage": "Copy the place of marriage exactly"
+          "copyPlaceOfMarriage": "Copy the place of marriage from your marriage certificate exactly"
         },
 
         "checkYourAnswersContent": {

--- a/app/steps/marriage/foreign-certificate/template.html
+++ b/app/steps/marriage/foreign-certificate/template.html
@@ -10,7 +10,9 @@
     {{ textField(
       name = 'countryName',
       field = fields.countryName,
-      hint = content.countryName
+      hint = content.countryName,
+      label = content.countryName,
+      labelClass = 'visually-hidden'
     ) }}
 </fieldset>
 
@@ -21,13 +23,17 @@
         {{ textField(
           name = 'placeOfMarriage',
           field = fields.placeOfMarriage,
-          hint = content.wordsOfTranslation
+          hint = content.wordsOfTranslation,
+          label = content.wordsOfTranslation,
+          labelClass = 'visually-hidden'
         )}}
       {% else %}
         <legend class="form-label-bold">{{ content.placeOfMarriage | safe }}</legend>
         {{ textField(
           name = 'placeOfMarriage',
-          field = fields.placeOfMarriage
+          field = fields.placeOfMarriage,
+          label = content.copyPlaceOfMarriage,
+          labelClass = 'visually-hidden'
         )}}
 
       {% endif %}

--- a/app/views/common/components/formElements.html
+++ b/app/views/common/components/formElements.html
@@ -15,9 +15,18 @@
     </div>
 {% endmacro %}
 
-{% macro textField(name, field, label, hint = '', boldLabel = false) %}
+{% macro textField(name, field, label, hint = '', boldLabel = false, labelClass = '') %}
+
+    {% if labelClass %}
+        {% set actualLabelClass = labelClass %}
+    {% elif boldLabel %}
+        {% set actualLabelClass = "form-label-bold text" %}
+    {% else %}
+        {% set actualLabelClass = "form-label text" %}
+    {% endif %}
+
     <div class="form-group {{ 'form-group-error' if field.error }}">
-      <label class="form-label{{ '-bold' if boldLabel }} text" for="{{ name }}">{{ label | safe }}</label>
+        <label class="{{ actualLabelClass }}" for="{{ name }}">{{ label | safe }}</label>
 
         {% if hint %}
             <span class="form-hint text">{{ hint | safe }}</span>

--- a/app/views/common/components/formElements.test.js
+++ b/app/views/common/components/formElements.test.js
@@ -106,7 +106,7 @@ describe(`Text areas should render as expected`, () => {
   });
 });
 
-describe.only(`Text fields should render as expected`, () => {
+describe(`Text fields should render as expected`, () => {
   it('name, field and label are rendered correctly', () => {
     const input = {
       name: 'testName',

--- a/app/views/common/components/formElements.test.js
+++ b/app/views/common/components/formElements.test.js
@@ -25,7 +25,17 @@ const textArea = `
 
 const textField = `
 {% from "app/views/common/components/formElements.html" import textField %}
-{{ textField(name, field, label, hint) }}
+{{
+  textField
+  (
+    name = name,
+    field = field,
+    label = label,
+    hint = hint,
+    boldLabel = boldLabel,
+    labelClass = labelClass
+  )
+}}
 `;
 
 const yesNoRadioButton = `
@@ -96,7 +106,7 @@ describe(`Text areas should render as expected`, () => {
   });
 });
 
-describe(`Text fields should render as expected`, () => {
+describe.only(`Text fields should render as expected`, () => {
   it('name, field and label are rendered correctly', () => {
     const input = {
       name: 'testName',
@@ -111,6 +121,30 @@ describe(`Text fields should render as expected`, () => {
     expect(res).to.contain('name="testName"');
     expect(res).to.contain(input.field.value);
     expect(res).to.not.contain('<span class="form-hint">');
+  });
+
+  it('label class is bold if requested', () => {
+    const input = {
+      name: 'testName',
+      field: { value: 'some text' },
+      label: 'testLabel',
+      boldLabel: true
+    };
+
+    const res = nunjucks.renderString(textField, input);
+    expect(res).to.contain('<label class="form-label-bold text" for="testName">testLabel</label>');
+  });
+
+  it('label class is applied if provided', () => {
+    const input = {
+      name: 'testName',
+      field: { value: 'some text' },
+      label: 'testLabel',
+      labelClass: 'hidden'
+    };
+
+    const res = nunjucks.renderString(textField, input);
+    expect(res).to.contain('<label class="hidden" for="testName">testLabel</label>');
   });
 
   it('errors are shown if present', () => {


### PR DESCRIPTION
# Description
changed base form elements definition for test fields to include the ability to specify a label class. Changed the foreign marriage certificate page to set labels with hint text for screen readers, with the labels having an invisibility class so they aren't displayed

Fixes # (issue)
DIV-2466, DIV-2504

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
unit tests, manually progressing through the divorce application story

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
