### PR TITLE
Clear the connect.sid cookie from exit pages

### DIFF
--- a/app/steps/bye/index.js
+++ b/app/steps/bye/index.js
@@ -4,6 +4,7 @@ const statusCodes = require('http-status-codes');
 
 module.exports = class ExitMarriageBroken extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     res.redirect(statusCodes.MOVED_PERMANENTLY, '/index');
   }
   get url() {

--- a/app/steps/bye/index.test.js
+++ b/app/steps/bye/index.test.js
@@ -11,6 +11,7 @@ describe(modulePath, () => {
 
   beforeEach(() => {
     res.redirect = sinon.spy();
+    res.clearCookie = sinon.spy();
     step = new UnderTest();
   });
 
@@ -20,5 +21,12 @@ describe(modulePath, () => {
     // Assert.
     expect(res.redirect.calledOnce).to.equal(true);
     expect(res.redirect.calledWith(statusCodes.MOVED_PERMANENTLY, '/index')).to.equal(true);
+  });
+
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
   });
 });

--- a/app/steps/done-and-submitted/index.js
+++ b/app/steps/done-and-submitted/index.js
@@ -4,6 +4,7 @@ const paymentService = require('app/services/payment');
 
 module.exports = class DoneAndSubmitted extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
 

--- a/app/steps/done-and-submitted/index.test.js
+++ b/app/steps/done-and-submitted/index.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const { expect, sinon } = require('test/util/chai');
 const { testContent, testExistence, testNonExistence } = require('test/util/assertions');
 const { withSession } = require('test/util/setup');
 const server = require('app');
@@ -7,6 +8,7 @@ const CONF = require('config');
 const modulePath = 'app/steps/done-and-submitted';
 
 const content = require(`${modulePath}/content`);
+const Step = require(modulePath);
 
 const contentStrings = content.resources.en.translation.content;
 const featureTogglesMock = require('test/mocks/featureToggles');
@@ -17,13 +19,25 @@ let agent = {};
 let underTest = {};
 
 describe(modulePath, () => {
+  const req = {};
+  const res = {};
+  let step = {};
+
   beforeEach(() => {
     featureTogglesMock.stub();
     s = server.init();
     agent = request.agent(s.app);
     underTest = s.steps.DoneAndSubmitted;
+    step = new Step();
+    res.clearCookie = sinon.spy();
   });
 
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
+  });
 
   afterEach(() => {
     s.http.close();

--- a/app/steps/exit/about-your-marriage/no-certificate-translated/index.js
+++ b/app/steps/exit/about-your-marriage/no-certificate-translated/index.js
@@ -3,6 +3,7 @@ const runStepHandler = require('app/core/handler/runStepHandler');
 
 module.exports = class ExitNoCertificateTranslated extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
   get url() {

--- a/app/steps/exit/screening-questions/has-marriage-broken/index.js
+++ b/app/steps/exit/screening-questions/has-marriage-broken/index.js
@@ -3,6 +3,7 @@ const runStepHandler = require('app/core/handler/runStepHandler');
 
 module.exports = class ExitMarriageBroken extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
   get url() {

--- a/app/steps/exit/screening-questions/has-marriage-broken/index.test.js
+++ b/app/steps/exit/screening-questions/has-marriage-broken/index.test.js
@@ -1,22 +1,36 @@
 const request = require('supertest');
+const { expect, sinon } = require('test/util/chai');
 const { testContent } = require('test/util/assertions');
 const server = require('app');
 
 const modulePath = 'app/steps/exit/screening-questions/has-marriage-broken';
 
 const content = require(`${modulePath}/content`);
+const Step = require(modulePath);
 
 let s = {};
 let agent = {};
 let underTest = {};
 
 describe(modulePath, () => {
+  const req = {};
+  const res = {};
+  let step = {};
+
   beforeEach(() => {
     s = server.init();
     agent = request.agent(s.app);
     underTest = s.steps.ExitMarriageBroken;
+    step = new Step();
+    res.clearCookie = sinon.spy();
   });
 
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
+  });
 
   afterEach(() => {
     s.http.close();

--- a/app/steps/exit/screening-questions/has-marriage-cert/index.js
+++ b/app/steps/exit/screening-questions/has-marriage-cert/index.js
@@ -3,6 +3,7 @@ const runStepHandler = require('app/core/handler/runStepHandler');
 
 module.exports = class ExitMarriageCertificate extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
   get url() {

--- a/app/steps/exit/screening-questions/has-marriage-cert/index.test.js
+++ b/app/steps/exit/screening-questions/has-marriage-cert/index.test.js
@@ -1,22 +1,36 @@
 const request = require('supertest');
+const { expect, sinon } = require('test/util/chai');
 const { testContent } = require('test/util/assertions');
 const server = require('app');
 
 const modulePath = 'app/steps/exit/screening-questions/has-marriage-cert';
 
 const content = require(`${modulePath}/content`);
+const Step = require(modulePath);
 
 let s = {};
 let agent = {};
 let underTest = {};
 
 describe(modulePath, () => {
+  const req = {};
+  const res = {};
+  let step = {};
+
   beforeEach(() => {
     s = server.init();
     agent = request.agent(s.app);
     underTest = s.steps.ExitMarriageCertificate;
+    step = new Step();
+    res.clearCookie = sinon.spy();
   });
 
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
+  });
 
   afterEach(() => {
     s.http.close();

--- a/app/steps/exit/screening-questions/has-respondent-address/index.js
+++ b/app/steps/exit/screening-questions/has-respondent-address/index.js
@@ -3,6 +3,7 @@ const runStepHandler = require('app/core/handler/runStepHandler');
 
 module.exports = class ExitRespondentAddress extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
   get url() {

--- a/app/steps/exit/screening-questions/has-respondent-address/index.test.js
+++ b/app/steps/exit/screening-questions/has-respondent-address/index.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest');
+const { expect, sinon } = require('test/util/chai');
 const { testContent } = require('test/util/assertions');
 const { withSession } = require('test/util/setup');
 const server = require('app');
@@ -6,18 +7,31 @@ const server = require('app');
 const modulePath = 'app/steps/exit/screening-questions/has-respondent-address';
 
 const content = require(`${modulePath}/content`);
+const Step = require(modulePath);
 
 let s = {};
 let agent = {};
 let underTest = {};
 
 describe(modulePath, () => {
+  const req = {};
+  const res = {};
+  let step = {};
+
   beforeEach(() => {
     s = server.init();
     agent = request.agent(s.app);
     underTest = s.steps.ExitRespondentAddress;
+    step = new Step();
+    res.clearCookie = sinon.spy();
   });
 
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
+  });
 
   afterEach(() => {
     s.http.close();

--- a/app/steps/save-resume/removed-saved-application/index.js
+++ b/app/steps/save-resume/removed-saved-application/index.js
@@ -7,6 +7,7 @@ module.exports = class ExitRemovedSavedApplication extends DestroySessionStep {
     return [draftPetitionStoreMiddleware.removeFromDraftStore];
   }
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
   get url() {

--- a/app/steps/save-resume/removed-saved-application/index.test.js
+++ b/app/steps/save-resume/removed-saved-application/index.test.js
@@ -1,22 +1,36 @@
 const request = require('supertest');
+const { expect, sinon } = require('test/util/chai');
 const { testContent } = require('test/util/assertions');
 const server = require('app');
 
 const modulePath = 'app/steps/save-resume/removed-saved-application';
 
 const content = require(`${modulePath}/content`);
+const Step = require(modulePath);
 
 let s = {};
 let agent = {};
 let underTest = {};
 
 describe(modulePath, () => {
+  const req = {};
+  const res = {};
+  let step = {};
+
   beforeEach(() => {
     s = server.init();
     agent = request.agent(s.app);
     underTest = s.steps.ExitRemovedSavedApplication;
+    step = new Step();
+    res.clearCookie = sinon.spy();
   });
 
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
+  });
 
   afterEach(() => {
     s.http.close();

--- a/app/steps/save-resume/save-and-close/index.js
+++ b/app/steps/save-resume/save-and-close/index.js
@@ -3,6 +3,7 @@ const runStepHandler = require('app/core/handler/runStepHandler');
 
 module.exports = class ExitApplicationSaved extends DestroySessionStep {
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
   get url() {

--- a/app/steps/save-resume/save-and-close/index.test.js
+++ b/app/steps/save-resume/save-and-close/index.test.js
@@ -1,22 +1,36 @@
 const request = require('supertest');
+const { expect, sinon } = require('test/util/chai');
 const { testContent } = require('test/util/assertions');
 const server = require('app');
 
 const modulePath = 'app/steps/save-resume/save-and-close';
 
 const content = require(`${modulePath}/content`);
+const Step = require(modulePath);
 
 let s = {};
 let agent = {};
 let underTest = {};
 
 describe(modulePath, () => {
+  const req = {};
+  const res = {};
+  let step = {};
+
   beforeEach(() => {
     s = server.init();
     agent = request.agent(s.app);
     underTest = s.steps.ExitApplicationSaved;
+    step = new Step();
+    res.clearCookie = sinon.spy();
   });
 
+  it('clears the connect.sid cookie', () => {
+    // Act.
+    step.handler(req, res);
+    // Assert.
+    expect(res.clearCookie.calledWith('connect.sid'));
+  });
 
   afterEach(() => {
     s.http.close();

--- a/app/steps/timeout/index.js
+++ b/app/steps/timeout/index.js
@@ -6,6 +6,7 @@ module.exports = class Timeout extends DestroySessionStep {
     return '/timeout';
   }
   handler(req, res) {
+    res.clearCookie('connect.sid');
     return runStepHandler(this, req, res);
   }
 };

--- a/app/steps/timeout/index.test.js
+++ b/app/steps/timeout/index.test.js
@@ -3,7 +3,7 @@ const { expect, sinon } = require('test/util/chai');
 const { testContent } = require('test/util/assertions');
 const server = require('app');
 
-const modulePath = 'app/steps/exit/about-your-marriage/no-certificate-translated';
+const modulePath = 'app/steps/timeout';
 
 const content = require(`${modulePath}/content`);
 const Step = require(modulePath);
@@ -20,7 +20,7 @@ describe(modulePath, () => {
   beforeEach(() => {
     s = server.init();
     agent = request.agent(s.app);
-    underTest = s.steps.ExitNoCertificateTranslated;
+    underTest = s.steps.Timeout;
     step = new Step();
     res.clearCookie = sinon.spy();
   });


### PR DESCRIPTION
# Description
It seems that when the session is destroyed, express does not delete the `connect.sid` cookie. That's why we delete the cookie manually in the exit pages

Fixes # [DIV-2498](https://tools.hmcts.net/jira/browse/DIV-2498)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This will be tested on Dev A on Tactical first

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
