### PR TITLE
DIV-2512: changed rejection pattern to only include original example …

### DIFF
--- a/app/steps/grounds-for-divorce/unreasonable-behaviour/index.js
+++ b/app/steps/grounds-for-divorce/unreasonable-behaviour/index.js
@@ -20,7 +20,7 @@ module.exports = class UnreasonableBehaviour extends ValidationStep {
     if (ctx.reasonForDivorceBehaviourDetails) {
       ctx.reasonForDivorceBehaviourDetails = ctx.reasonForDivorceBehaviourDetails.filter( // eslint-disable-line max-len
         item => {
-          return !isEmpty(item) && !item.match(/^(?=My (husband|wife|\.\.\.|)( | \.\.\.|)$)/);
+          return !isEmpty(item) && !item.match(/^(?=My (husband|wife) \.\.\.$)/);
         }
       );
     } else {


### PR DESCRIPTION
# Description
Changed pattern restricting reason entered to only reject the original example string placed in the reason textarea

Fixes # (issue)
DIV-2512

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested via unit tests and manually following the divorce application story

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
