### PR TITLE
Fix localhost cookie domain setting

### DIFF
--- a/app/middleware/sessions.js
+++ b/app/middleware/sessions.js
@@ -68,7 +68,7 @@ const sessions = module.exports = { // eslint-disable-line no-multi-assign
         cookie: {
           secure: cookieSecure,
           httpOnly: true,
-          domain: req.get('host')
+          domain: req.hostname
         }
       })(req, res, sessionHandled);
     };

--- a/app/services/idam.js
+++ b/app/services/idam.js
@@ -20,10 +20,11 @@ const idamArgs = {
 
 module.exports = {
 
-  authenticate: (protocol, hostName, path) => {
-    if (hostName) {
-      idamArgs.hostName = hostName;
-      idamArgs.redirectUri = protocol.concat('://', hostName, path);
+  authenticate: (protocol, host, path) => {
+    if (host) {
+      // get the hostname part of the host string
+      idamArgs.hostName = host.split(':')[0];
+      idamArgs.redirectUri = protocol.concat('://', host, path);
     }
     return idamExpressMiddleware.authenticate(idamArgs);
   },

--- a/app/steps/start/index.test.js
+++ b/app/steps/start/index.test.js
@@ -40,8 +40,8 @@ describe(modulePath, () => {
 
     it('should set up the current host as the redirect uri for idam', done => {
       testCustom(done, agent, underTest, [], response => {
-        const hostName = response.request.host;
-        const redirectUri = response.request.protocol.concat('//', hostName, '/authenticated');
+        const hostName = response.request.host.split(':')[0];
+        const redirectUri = response.request.protocol.concat('//', response.request.host, '/authenticated');
         const confIdam = CONF.idamArgs;
         const idamArgs = {
           hostName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,7 +5193,7 @@ nightmare-upload@^0.1.1:
   dependencies:
     debug "^2.2.0"
 
-nightmare@^2.3.0:
+nightmare@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nightmare/-/nightmare-2.10.0.tgz#e9c5d590bb296f59685fd48218c2fbac44767b21"
   dependencies:


### PR DESCRIPTION
Was setting cookie domains with the whole host (name + port). Cookie domains don't like the port, so am just passing in the hostname part into the session cookie and the idam state cookies.

Just a clarification on the changes I am making:

req.protocol => return 'http' or 'https' etc.
req.hostname => returns the hostname without a port, so 'localhost' or 'divorce.reform.hmcts.net'
req.get('host') => returns the full host, so 'localhost:8080' or 'divorce.reform.hmcts.net' (not sure if it appends the 80/443 actually)
There is no req.port so the way I retrieve port is through req.get('host').split[1]. As any proper hostname will have in hostname:port format, no protocol.
Any hostnames with more than one ':'  is most likely invalid.