### PR TITLE
Div-2441 cya page does not contain answer to do you have a help with fees reference number when petitioner has answered no

### DIFF
--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -153,6 +153,19 @@ describe(modulePath, () => {
     });
   });
 
+  describe.only('help with fees reference number does not exist', () => {
+    let session = {};
+    beforeEach(done => {
+      session = clone(mockSession);
+      session.helpWithFeesReferenceNumber = '';
+      session.helpWithFeesNeedHelp = 'Yes';
+      withSession(done, agent, session);
+    });
+    it('renders the correct dynamic text', done => {
+      testExistence(done, agent, underTest, "No", session);
+    });
+  });
+
   describe('prayer section', () => {
     beforeEach(done => {
       const session = clone(mockSession);

--- a/app/steps/help/with-fees/index.js
+++ b/app/steps/help/with-fees/index.js
@@ -61,6 +61,6 @@ module.exports = class WithFees extends OptionStep {
   }
 
   checkYourAnswersInterceptor(ctx) {
-    return { helpWithFeesReferenceNumber: ctx.helpWithFeesReferenceNumber };
+    return { helpWithFeesReferenceNumber: ctx.helpWithFeesReferenceNumber || 'No' };
   }
 };

--- a/app/steps/help/with-fees/index.test.js
+++ b/app/steps/help/with-fees/index.test.js
@@ -254,5 +254,13 @@ describe(modulePath, () => {
       testExistenceCYA(done, underTest, content,
         contentToExist, valuesToExist, context);
     });
+
+    it('renders HWF number as No for when no HWF number is present', done => {
+      const contentToExist = ['question'];
+      const valuesToExist = ['helpWithFeesReferenceNumber'];
+      const context = { helpWithFeesReferenceNumber: 'No' };
+
+      testExistenceCYA(done, underTest, content, contentToExist, valuesToExist, context);
+    });
   });
 });


### PR DESCRIPTION
# Description
Change CYA page to display "No" if a user has indicated that fees help is required but has not specified a fees help reference number

Fixes # (issue)
DIV-2441

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
By manually following the divorce application story locally, and via unit tests

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
