### PR TITLE
Div 2229 readonly email contact details

### DIFF
--- a/app/assets/sass/_contact-details.scss
+++ b/app/assets/sass/_contact-details.scss
@@ -14,9 +14,5 @@
       margin-left: 50px;
     }
   }
-
-  .email-font {
-    font-weight: bold;
-  }
 }
 

--- a/app/assets/sass/_contact-details.scss
+++ b/app/assets/sass/_contact-details.scss
@@ -1,0 +1,18 @@
+.contact-details {
+
+  .confirmation-container {
+    background: #dee0e2;
+    padding: 25px;
+    .multiple-choice [type=checkbox] + label::before {
+      background: #fff;
+    }
+
+    .list-bullet {
+      padding-left: 70px;
+    }
+    .text {
+      margin-left: 50px;
+    }
+  }
+}
+

--- a/app/assets/sass/_contact-details.scss
+++ b/app/assets/sass/_contact-details.scss
@@ -14,5 +14,9 @@
       margin-left: 50px;
     }
   }
+
+  .email-font {
+    font-weight: bold;
+  }
 }
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -18,6 +18,7 @@
 @import 'phase-banner';
 @import 'patterns/facts';
 @import 'check-your-answers';
+@import 'contact-details';
 @import 'reason-for-divorce';
 @import 'dropzone';
 

--- a/app/steps/petitioner/contact-details/content.json
+++ b/app/steps/petitioner/contact-details/content.json
@@ -20,10 +20,6 @@
                 },
 
                 "errors": {
-                    "petitionerEmail": {
-                        "required": "Enter your email address",
-                        "invalid": "Enter a valid email address"
-                    },
                     "petitionerPhoneNumber": {
                         "invalid": "Enter a valid telephone number. Telephone number must be a minimum length of 9 and can only contain the numbers 0-9 and the symbols +, - , ( , ) , ."
                     },

--- a/app/steps/petitioner/contact-details/content.json
+++ b/app/steps/petitioner/contact-details/content.json
@@ -4,11 +4,13 @@
         "en": {
             "translation": {
                 "content": {
-                    "question": "Enter your contact details",
-                    "communicate": "You need to agree to receive notifications about your divorce and court documents by email.",
+                    "question": "How you'll be contacted",
+                    "communicateParagraph1": "You'll be sent emails by the court throughout the divorce.<br/> You must agree to receive these emails to use this service.",
+                    "communicateParagraph2": "The court will send email notifications to:",
+                    "communicateParagraph3": "You can provide a UK phone number as another way for the court to contact you. This is optional.",
                     "confidentialContactDetails": "Your email address and phone number will be kept confidential from your {{ divorceWho }}.",
                     "email": "Your email address",
-                    "petitionerPhoneNumber": "Your phone number",
+                    "petitionerPhoneNumber": "Enter your phone number",
                     "petitionerConsent": "I agree that the divorce centre can send me notifications and deliver (serve) court documents to me by email."
                 },
 

--- a/app/steps/petitioner/contact-details/index.test.js
+++ b/app/steps/petitioner/contact-details/index.test.js
@@ -70,17 +70,6 @@ describe(modulePath, () => {
       testErrors(done, agent, underTest, {}, content, 'required');
     });
 
-    it('renders errors for invalid email', done => {
-      const context = {
-        petitionerEmail: 'firstnamelatsname.com',
-        petitionerConsent: 'Yes'
-      };
-
-      const onlyKeys = ['email'];
-
-      testErrors(done, agent, underTest, context, content, 'invalid', onlyKeys);
-    });
-
     it('renders errors for invalid phone', done => {
       const context = {
         petitionerEmail: 'firstname@latsname.com',

--- a/app/steps/petitioner/contact-details/partials/checkYourAnswersTemplate.html
+++ b/app/steps/petitioner/contact-details/partials/checkYourAnswersTemplate.html
@@ -1,7 +1,6 @@
 <tr>
   <th>{{ content.email | safe }}</th>
   <td>{{ fields.petitionerEmail.value }}</td>
-  <td><a class="link" aria-label="{{ content.change }} {{ content.email | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>
 </tr>
 {% if fields.petitionerPhoneNumber.value %}
   <tr>

--- a/app/steps/petitioner/contact-details/schema.json
+++ b/app/steps/petitioner/contact-details/schema.json
@@ -19,7 +19,6 @@
     }
   },
   "required": [
-    "petitionerEmail",
     "petitionerConsent"
   ]
 

--- a/app/steps/petitioner/contact-details/template.html
+++ b/app/steps/petitioner/contact-details/template.html
@@ -8,7 +8,7 @@
 
 {% block form %}
 
-<main id="content" role="main" tabindex="-1" class="contact-details">
+<main role="main" tabindex="-1" class="contact-details">
 
   <p>{{ content.communicateParagraph1 | safe }}</p>
 
@@ -17,7 +17,7 @@
   {% endif %}
 
   <p>{{ content.communicateParagraph2 | safe }}</p>
-  <p><strong>{{ fields.petitionerEmail.value | safe }}</strong></p>
+  <p class="email-font">{{ fields.petitionerEmail.value | safe }}</p>
 
   <fieldset class="form-group confirmation-container {{ ' form-group-error' if fields.petitionerConsent.error }}">
     <legend class="visually-hidden">{{ content.petitionerConsent | safe }}</legend>

--- a/app/steps/petitioner/contact-details/template.html
+++ b/app/steps/petitioner/contact-details/template.html
@@ -8,21 +8,35 @@
 
 {% block form %}
 
-  <p>{{ content.communicate | safe }}</p>
+<main id="content" role="main" tabindex="-1" class="contact-details">
+
+  <p>{{ content.communicateParagraph1 | safe }}</p>
 
   {% if session.petitionerContactDetailsConfidential != 'share' %}
     <p class="panel panel-border-wide">{{ content.confidentialContactDetails | safe }}</p>
   {% endif %}
 
+  <p>{{ content.communicateParagraph2 | safe }}</p>
+  <p><strong>{{ fields.petitionerEmail.value | safe }}</strong></p>
+
+  <fieldset class="form-group confirmation-container {{ ' form-group-error' if fields.petitionerConsent.error }}">
+    <legend class="visually-hidden">{{ content.petitionerConsent | safe }}</legend>
+    {{ errorsFor(fields.petitionerConsent) }}
+
+      {{ checkBox(
+      id = 'petitionerConsent',
+      name = 'petitionerConsent',
+      field = fields.petitionerConsent,
+      value = fields.petitionerConsent.value,
+      label = content.petitionerConsent
+      ) }}
+
+  </fieldset>
+
   <fieldset class="form-group">
     <legend class="visually-hidden">{{ content.question | safe }}</legend>
 
-    {{ textField(
-      name = 'petitionerEmail',
-      field = fields.petitionerEmail,
-      label = content.email
-    ) }}
-
+    <p>{{ content.communicateParagraph3 | safe }}</p>
     {{ textField(
       name = 'petitionerPhoneNumber',
       field = fields.petitionerPhoneNumber,
@@ -31,17 +45,7 @@
 
   </fieldset>
 
-  <fieldset class="form-group {{ ' form-group-error' if fields.petitionerConsent.error }}">
-    <legend class="visually-hidden">{{ content.petitionerConsent | safe }}</legend>
-    {{ errorsFor(fields.petitionerConsent) }}
 
-    {{ checkBox(
-      id = 'petitionerConsent',
-      name = 'petitionerConsent',
-      field = fields.petitionerConsent,
-      label = content.petitionerConsent
-    ) }}
-
-  </fieldset>
+</main>
 
 {% endblock %}

--- a/app/steps/petitioner/contact-details/template.html
+++ b/app/steps/petitioner/contact-details/template.html
@@ -17,7 +17,7 @@
   {% endif %}
 
   <p>{{ content.communicateParagraph2 | safe }}</p>
-  <p class="email-font">{{ fields.petitionerEmail.value | safe }}</p>
+  <p class="bold-medium">{{ fields.petitionerEmail.value | safe }}</p>
 
   <fieldset class="form-group confirmation-container {{ ' form-group-error' if fields.petitionerConsent.error }}">
     <legend class="visually-hidden">{{ content.petitionerConsent | safe }}</legend>

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -122,15 +122,15 @@ commonProps:
   courtEmail: 'simulate-delivered@notifications.service.gov.uk'
 
 features:
-  idam: false
+  idam: true
   fullPaymentEventDataSubmission: true
 
 idamArgs:
   redirectUri: 'https://localhost:8080/authenticated'
   indexUrl: '/index'
-  idamApiUrl: 'http://localhost:8001'
-  idamLoginUrl: 'https://localhost:8000/login'
-  idamSecret: '123456'
+  idamApiUrl: 'http://betaDevBccidamAppLB.reform.hmcts.net:80'
+  idamLoginUrl: 'https://idam-test.dev.ccidam.reform.hmcts.net/login'
+  idamSecret: 'NeSwukuV8jepreQa3u36nafaCREcUsp5'
   idamClientID: 'divorce'
 
 evidenceManagmentClient:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -122,15 +122,15 @@ commonProps:
   courtEmail: 'simulate-delivered@notifications.service.gov.uk'
 
 features:
-  idam: true
+  idam: false
   fullPaymentEventDataSubmission: true
 
 idamArgs:
   redirectUri: 'https://localhost:8080/authenticated'
   indexUrl: '/index'
-  idamApiUrl: 'http://betaDevBccidamAppLB.reform.hmcts.net:80'
-  idamLoginUrl: 'https://idam-test.dev.ccidam.reform.hmcts.net/login'
-  idamSecret: 'NeSwukuV8jepreQa3u36nafaCREcUsp5'
+  idamApiUrl: 'http://localhost:8001'
+  idamLoginUrl: 'https://localhost:8000/login'
+  idamSecret: '123456'
   idamClientID: 'divorce'
 
 evidenceManagmentClient:

--- a/test/util/assertions.js
+++ b/test/util/assertions.js
@@ -144,7 +144,9 @@ exports.testCYATemplate = (done, underTest) => {
   };
 
   const checkChangeLink = (html) => {
-    expect(html).to.contain(underTest.url);
+    if(! html.toString().includes('Your email address')){ //email is now read-only, should not include change link
+      expect(html).to.contain(underTest.url);
+    }
   };
 
   return getCYATemplate(underTest)


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-2229

Fixes # (issue)

## Type of change

Screen changes done. 
Email address on contact details page is now read-only
Contact detail page content is now as per screen design in the JIRA.
Removed email address change or validation codes.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules