### PR TITLE
Cya textwrap

### DIFF
--- a/app/assets/sass/_check-your-answers.scss
+++ b/app/assets/sass/_check-your-answers.scss
@@ -7,8 +7,12 @@
   }
 
   td {
-    vertical-align:top;
+    vertical-align: top;
+    -ms-word-break: break-all;
     word-break: break-all;
+
+    /* Non standard for WebKit */
+    word-break: break-word;
   }
 
   td.no-border {


### PR DESCRIPTION
# Description
[DIV-1448 - Text not wrapping correctly on CYA](https://tools.hmcts.net/jira/browse/DIV-1448)
Remove css rules that are breaking the words on CYA page


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
