### PR TITLE
Changed to public IDAM login url

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -12,7 +12,7 @@ google_analytics_tracking_id = "UA-93824767-3"
 
 rediscloud_url = "betaProddivorceCache01.reform.hmcts.net:6379"
 
-idam_authentication_web_url = "https://www.idam.reform.hmcts.net"
+idam_authentication_web_url = "https://hmcts-access.service.gov.uk"
 idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"
 service_auth_provider_url = "https://prod-s2s-api.reform.hmcts.net:3511"
 


### PR DESCRIPTION
Production was pointing to tactical IDAM private beta.