### PR TITLE
reset session expiry after idam login

### DIFF
--- a/app/steps/authenticated/index.js
+++ b/app/steps/authenticated/index.js
@@ -2,12 +2,23 @@ const Step = require('app/core/steps/Step');
 const idam = require('app/services/idam');
 const { features } = require('@hmcts/div-feature-toggle-client')().featureToggles;
 const initSession = require('app/middleware/initSession');
-const sessionTimeout = require('app/middleware/sessionTimeout');
 
 const idamLandingPage = (req, res, next) => {
   if (features.idam) {
     const landing = idam.landingPage();
-    return landing(req, res, next);
+    return landing(req, res, () => {
+      const { session } = req;
+
+      // if the previous session has expired
+      // after user logged in then destroy it
+      if (session.expires <= Date.now()) {
+        req.session.destroy(() => {
+          next();
+        });
+      } else {
+        next();
+      }
+    });
   }
 
   return next();
@@ -25,7 +36,6 @@ module.exports = class Authenticated extends Step {
   get middleware() {
     return [
       initSession,
-      sessionTimeout,
       idamLandingPage
     ];
   }

--- a/app/steps/authenticated/index.test.js
+++ b/app/steps/authenticated/index.test.js
@@ -1,11 +1,14 @@
 /* eslint-disable max-nested-callbacks */
 const request = require('supertest');
-const { testRedirect, getSession } = require('test/util/assertions');
+const { testRedirect, getSession, testCustom } = require('test/util/assertions');
 const server = require('app');
 const idamMock = require('test/mocks/idam');
 const featureTogglesMock = require('test/mocks/featureToggles');
 const idam = require('app/services/idam');
 const { expect, sinon } = require('test/util/chai');
+const { withSession } = require('test/util/setup');
+const { mockSession } = require('test/fixtures');
+const { clone } = require('lodash');
 
 const modulePath = 'app/steps/authenticated';
 
@@ -57,6 +60,59 @@ describe(modulePath, () => {
             expect(landingPageStub.calledOnce).to.eql(true);
           })
           .then(done, done);
+      });
+    });
+
+    describe('with expired session', () => {
+      const session = clone(mockSession);
+      beforeEach(done => {
+        session.expires = 1;
+        withSession(done, agent, session);
+      });
+
+      it('ensure session data is destroyed if expired after user login', done => {
+        expect(session.hasOwnProperty('courts')).to.eql(true);
+
+        const testSession = () => {
+          getSession(agent)
+            .then(newSession => {
+              expect(newSession.hasOwnProperty('courts')).to.eql(false);
+            })
+            .then(done, done);
+        };
+
+        const emptyCallback = () => {}; // eslint-disable-line
+
+        const featureMock = featureTogglesMock
+          .when('idam', true, testCustom, agent, underTest, [], emptyCallback, 'post', false);
+        featureMock(testSession);
+      });
+    });
+
+    describe('with valid session', () => {
+      const session = clone(mockSession);
+      beforeEach(done => {
+        const thousand = 1000;
+        session.expires = Date.now() + thousand;
+        withSession(done, agent, session);
+      });
+
+      it('ensure session data is still there after user login', done => {
+        expect(session.hasOwnProperty('courts')).to.eql(true);
+
+        const testSession = () => {
+          getSession(agent)
+            .then(newSession => {
+              expect(newSession.hasOwnProperty('courts')).to.eql(true);
+            })
+            .then(done, done);
+        };
+
+        const emptyCallback = () => {}; // eslint-disable-line
+
+        const featureMock = featureTogglesMock
+          .when('idam', true, testCustom, agent, underTest, [], emptyCallback, 'post', false);
+        featureMock(testSession);
       });
     });
   });

--- a/test/util/assertions.js
+++ b/test/util/assertions.js
@@ -1,4 +1,3 @@
-/*eslint no-console: "off"*/
 const CONF = require('config');
 const { forEach, get, isArray, isObject, clone } = require('lodash');
 const { expect } = require('test/util/chai');
@@ -405,7 +404,7 @@ exports.testHttpStatus = (done, agent, underTest, status, method = 'get') => {
     .then(() => done(), done);
 };
 
-exports.testCustom = (done, agent, underTest, cookies = [], callback, method = 'get') => {
+exports.testCustom = (done, agent, underTest, cookies = [], callback, method = 'get', createsNewSession = true) => {
   const runCallback = () => {
     let request = agent[method](underTest.url);
 
@@ -421,7 +420,12 @@ exports.testCustom = (done, agent, underTest, cookies = [], callback, method = '
       .expect(callback);
   };
 
-  return createSession(agent)
-    .then(runCallback)
-    .then(() => done(), done);
+  if (createsNewSession) {
+    return createSession(agent)
+      .then(runCallback)
+      .then(() => done(), done);
+  } else {
+    return runCallback()
+      .then(() => done(), done);
+  }
 };

--- a/test/util/setup.js
+++ b/test/util/setup.js
@@ -13,6 +13,9 @@ exports.withSession = (done, agent, data = {}) => {
         .set('X-CSRF-token', csrfToken)
         .send(data)
         .expect(200)
-        .end(done);
+        .end(() => {
+          agent.csrfToken = csrfToken;
+          done();
+        });
     });
 };


### PR DESCRIPTION
# Description
[DIV-2014 - 1 day spike: After session timeout user needs to sign in twice](https://tools.hmcts.net/jira/browse/DIV-2014)

After a user has logged into IDAM reset the session expiry date

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Manually and unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
