### PR TITLE
Div 1114 switch env vars to use config correctly in frontend

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,8 +18,9 @@ const errorHandler = require('app/core/errorHandler');
 const manifest = require('manifest.json');
 const helmet = require('helmet');
 const csurf = require('csurf');
+const environment = CONF.environment;
 const { fetchToggles } = require('@hmcts/div-feature-toggle-client')({
-  env: process.env.NODE_ENV,
+  env: environment,
   featureToggleApiUrl: CONF.services.featureToggleApiUrl
 });
 const i18nTemplate = require('app/core/utils/i18nTemplate')({
@@ -44,7 +45,7 @@ const PORT = CONF.http.port || CONF.http.porttactical;
 const logger = logging.Logger.getLogger(__filename);
 
 exports.init = () => {
-  if (process.env.NODE_ENV === 'production') {
+  if (environment === 'production') {
     appInsights.setup(CONF.applicationInsights.instrumentationKey).start();
   }
 
@@ -173,7 +174,7 @@ exports.init = () => {
   //  register steps with the express app
   const steps = initSteps(app, stepDefinitions);
 
-  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'testing') {
+  if (environment === 'development' || environment === 'testing') {
     //  site graph
     app.get('/graph', (req, res) => {
       const graph = siteGraph(steps);
@@ -202,12 +203,12 @@ exports.init = () => {
     res.render(view, {});
   }));
 
-  if (process.env.NODE_ENV !== 'testing') {
+  if (environment !== 'testing') {
     app.use(errorHandler(steps));
   }
 
   let http = {};
-  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'testing') {
+  if (environment === 'development' || environment === 'testing') {
     const sslDirectory = path.join(__dirname, 'app', 'resources', 'localhost-ssl');
 
     const sslOptions = {

--- a/app.js
+++ b/app.js
@@ -18,9 +18,8 @@ const errorHandler = require('app/core/errorHandler');
 const manifest = require('manifest.json');
 const helmet = require('helmet');
 const csurf = require('csurf');
-const environment = CONF.environment;
 const { fetchToggles } = require('@hmcts/div-feature-toggle-client')({
-  env: environment,
+  env: CONF.environment,
   featureToggleApiUrl: CONF.services.featureToggleApiUrl
 });
 const i18nTemplate = require('app/core/utils/i18nTemplate')({
@@ -45,7 +44,7 @@ const PORT = CONF.http.port || CONF.http.porttactical;
 const logger = logging.Logger.getLogger(__filename);
 
 exports.init = () => {
-  if (environment === 'production') {
+  if (CONF.environment === 'production') {
     appInsights.setup(CONF.applicationInsights.instrumentationKey).start();
   }
 
@@ -174,7 +173,7 @@ exports.init = () => {
   //  register steps with the express app
   const steps = initSteps(app, stepDefinitions);
 
-  if (environment === 'development' || environment === 'testing') {
+  if (CONF.environment === 'development' || CONF.environment === 'testing') {
     //  site graph
     app.get('/graph', (req, res) => {
       const graph = siteGraph(steps);
@@ -203,12 +202,12 @@ exports.init = () => {
     res.render(view, {});
   }));
 
-  if (environment !== 'testing') {
+  if (CONF.environment !== 'testing') {
     app.use(errorHandler(steps));
   }
 
   let http = {};
-  if (environment === 'development' || environment === 'testing') {
+  if (CONF.environment === 'development' || CONF.environment === 'testing') {
     const sslDirectory = path.join(__dirname, 'app', 'resources', 'localhost-ssl');
 
     const sslOptions = {

--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ const helmet = require('helmet');
 const csurf = require('csurf');
 const { fetchToggles } = require('@hmcts/div-feature-toggle-client')({
   env: process.env.NODE_ENV,
-  featureToggleApiUrl: process.env.FEATURE_TOGGLE_API_URL || CONF.services.featureToggleApiUrl
+  featureToggleApiUrl: CONF.services.featureToggleApiUrl
 });
 const i18nTemplate = require('app/core/utils/i18nTemplate')({
   viewDirectory: './app/views/',
@@ -39,7 +39,7 @@ const healthcheck = require('app/services/healthcheck');
 const featureToggleList = require('app/services/featureToggleList');
 const nunjucksFilters = require('app/filters/nunjucks');
 
-const PORT = process.env.PORT || process.env.HTTP_PORT || CONF.http.port;
+const PORT = CONF.http.port || CONF.http.porttactical;
 
 const logger = logging.Logger.getLogger(__filename);
 

--- a/app/core/handler/runStepHandler.js
+++ b/app/core/handler/runStepHandler.js
@@ -7,7 +7,6 @@ const transformationServiceClient = require('app/services/transformationServiceC
 const mockedClient = require('app/services/mocks/transformationServiceClient');
 const CONF = require('config');
 const sessionBlacklistedAttributes = require('app/resources/sessionBlacklistedAttributes');
-const environment = CONF.environment;
 
 const authTokenString = '__auth-token';
 
@@ -18,7 +17,7 @@ const options = {
 
 const saveSessionToDraftPetitionStore = (req, session,
   saveAndResumeUrl, sendEmail) => {
-  const production = environment === 'production';
+  const production = CONF.environment === 'production';
   const client = production ? transformationServiceClient.init(options) : mockedClient;
 
   // Properties that should be removed from the session before saving to draft store
@@ -138,7 +137,7 @@ module.exports = curry((step, req, res) => {
           } catch (error) {
             res.sendStatus(statusCode.INTERNAL_SERVER_ERROR);
           }
-        } else if (environment === 'testing') {
+        } else if (CONF.environment === 'testing') {
           // if running unit tests
           //  fetch all the content from the content files
           const content = yield step.generateContent(ctx, session);

--- a/app/core/handler/runStepHandler.js
+++ b/app/core/handler/runStepHandler.js
@@ -7,6 +7,7 @@ const transformationServiceClient = require('app/services/transformationServiceC
 const mockedClient = require('app/services/mocks/transformationServiceClient');
 const CONF = require('config');
 const sessionBlacklistedAttributes = require('app/resources/sessionBlacklistedAttributes');
+const environment = CONF.environment;
 
 const authTokenString = '__auth-token';
 
@@ -17,7 +18,7 @@ const options = {
 
 const saveSessionToDraftPetitionStore = (req, session,
   saveAndResumeUrl, sendEmail) => {
-  const production = process.env.NODE_ENV === 'production';
+  const production = environment === 'production';
   const client = production ? transformationServiceClient.init(options) : mockedClient;
 
   // Properties that should be removed from the session before saving to draft store
@@ -137,7 +138,7 @@ module.exports = curry((step, req, res) => {
           } catch (error) {
             res.sendStatus(statusCode.INTERNAL_SERVER_ERROR);
           }
-        } else if (process.env.NODE_ENV === 'testing') {
+        } else if (environment === 'testing') {
           // if running unit tests
           //  fetch all the content from the content files
           const content = yield step.generateContent(ctx, session);

--- a/app/middleware/draftPetitionStoreMiddleware.js
+++ b/app/middleware/draftPetitionStoreMiddleware.js
@@ -9,7 +9,8 @@ const options = {
   draftBaseUrl: CONF.services.transformation.draftBaseUrl,
   baseUrl: CONF.services.transformation.baseUrl
 };
-const production = process.env.NODE_ENV === 'production';
+
+const production = CONF.environment === 'production';
 const client = production ? transformationServiceClient.init(options) : mockedClient;
 
 const checkYourAnswers = '/check-your-answers';

--- a/app/middleware/sessions.js
+++ b/app/middleware/sessions.js
@@ -6,7 +6,7 @@ const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 const ioRedis = require('ioredis');
 
 const secret = CONF.secret;
-const redisHost = process.env.REDISCLOUD_URL || CONF.services.redis.host;
+const redisHost = CONF.services.redis.host;
 const ttl = CONF.session.ttl;
 const cookieSecure = process.env.PUBLIC_PROTOCOL === 'https';
 

--- a/app/middleware/sessions.js
+++ b/app/middleware/sessions.js
@@ -5,15 +5,17 @@ const sessionSerializer = require('app/services/sessionSerializer');
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 const ioRedis = require('ioredis');
 
+
 const secret = CONF.secret;
 const redisHost = CONF.services.redis.host;
 const ttl = CONF.session.ttl;
 const cookieSecure = process.env.PUBLIC_PROTOCOL === 'https';
+const environment = CONF.environment;
 
 const sessions = module.exports = { // eslint-disable-line no-multi-assign
 
   prod: (req, res, next) => {
-    if (process.env.NODE_ENV === 'testing') {
+    if (environment === 'testing') {
       return sessions.inmemory();
     }
 

--- a/app/middleware/sessions.js
+++ b/app/middleware/sessions.js
@@ -5,17 +5,15 @@ const sessionSerializer = require('app/services/sessionSerializer');
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 const ioRedis = require('ioredis');
 
-
 const secret = CONF.secret;
 const redisHost = CONF.services.redis.host;
 const ttl = CONF.session.ttl;
 const cookieSecure = process.env.PUBLIC_PROTOCOL === 'https';
-const environment = CONF.environment;
 
 const sessions = module.exports = { // eslint-disable-line no-multi-assign
 
   prod: (req, res, next) => {
-    if (environment === 'testing') {
+    if (CONF.environment === 'testing') {
       return sessions.inmemory();
     }
 

--- a/app/middleware/sessions.test.js
+++ b/app/middleware/sessions.test.js
@@ -26,7 +26,7 @@ describe(modulePath, () => {
     sessionSerializer.createSerializer.restore();
   });
 
-  describe('#prod', () => {
+  describe.only('#prod', () => {
     it('should use memory if NODE_ENV is testing', done => {
       process.env.NODE_ENV = 'testing';
       const session = sessions.prod();

--- a/app/middleware/sessions.test.js
+++ b/app/middleware/sessions.test.js
@@ -3,16 +3,17 @@ const sessionSerializer = require('app/services/sessionSerializer');
 
 const modulePath = 'app/middleware/sessions';
 const sessions = require(modulePath);
+const CONF = require('config');
 
 let req = {};
 let res = {};
 let next = {};
 const serializer = {};
-const prevNodeEnv = process.env.NODE_ENV;
+const prevNodeEnv = CONF.environment;
 
 describe(modulePath, () => {
   beforeEach(() => {
-    delete process.env.NODE_ENV;
+    delete CONF.environment;
     req = {
       originalUrl: '/',
       headers: { },
@@ -22,13 +23,13 @@ describe(modulePath, () => {
     sinon.stub(sessionSerializer, 'createSerializer').returns(serializer);
   });
   afterEach(() => {
-    process.env.NODE_ENV = prevNodeEnv;
+    CONF.environment = prevNodeEnv;
     sessionSerializer.createSerializer.restore();
   });
 
-  describe.only('#prod', () => {
+  describe('#prod', () => {
     it('should use memory if NODE_ENV is testing', done => {
-      process.env.NODE_ENV = 'testing';
+      CONF.environment = 'testing';
       const session = sessions.prod();
       next = () => {
         expect(req.sessionStore.constructor.name).to.eql('MemoryStore');

--- a/app/middleware/updateApplicationFeeMiddleware.js
+++ b/app/middleware/updateApplicationFeeMiddleware.js
@@ -10,7 +10,7 @@ const redisHost = CONF.services.redis.host;
 // redisClient is a let so it can be rewired in tests
 let redisClient = {};
 
-if (process.env.NODE_ENV === 'testing') {
+if (CONF.environment === 'testing') {
   redisClient = ioRedisMock();
 } else {
   redisClient = new ioRedis(redisHost); // eslint-disable-line prefer-const

--- a/app/services/idam.js
+++ b/app/services/idam.js
@@ -12,10 +12,10 @@ const landingPageUrl = PUBLIC_HOSTNAME ? redirectUri : confIdam.redirectUri;
 const idamArgs = {
   redirectUri: landingPageUrl,
   indexUrl: confIdam.indexUrl,
-  idamApiUrl: process.env.IDAM_API_URL || confIdam.idamApiUrl,
-  idamLoginUrl: process.env.IDAM_LOGIN_URL || confIdam.idamLoginUrl,
-  idamSecret: process.env.IDAM_SECRET || confIdam.idamSecret,
-  idamClientID: process.env.IDAM_CLIENT_ID || confIdam.idamClientID
+  idamApiUrl: confIdam.idamApiUrl,
+  idamLoginUrl: confIdam.idamLoginUrl,
+  idamSecret: confIdam.idamSecret,
+  idamClientID: confIdam.idamClientID
 };
 
 module.exports = {

--- a/app/services/rateLimiter.js
+++ b/app/services/rateLimiter.js
@@ -3,7 +3,7 @@ const ioRedis = require('ioredis');
 const expressLimiter = require('express-limiter');
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 
-const redisHost = process.env.REDISCLOUD_URL || CONF.services.redis.host;
+const redisHost = CONF.services.redis.host;
 
 module.exports = app => {
   const client = ioRedis.createClient(redisHost);

--- a/app/steps/pay/gov-pay-stub/index.js
+++ b/app/steps/pay/gov-pay-stub/index.js
@@ -2,6 +2,7 @@ const statusCodes = require('http-status-codes');
 const OptionStep = require('app/core/OptionStep');
 const runStepHandler = require('app/core/handler/runStepHandler');
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
+const CONF = require('config');
 
 module.exports = class GovPayStub extends OptionStep {
   get enabledAfterSubmission() {
@@ -22,7 +23,7 @@ module.exports = class GovPayStub extends OptionStep {
   }
 
   handler(req, res) {
-    if (process.env.NODE_ENV === 'production') {
+    if (CONF.environment === 'production') {
       // Fail early.
       logger.error(new Error('Payment stub page requested in production mode'));
       return res.status(statusCodes.NOT_FOUND).send('Not found');

--- a/app/steps/pay/gov-pay-stub/index.test.js
+++ b/app/steps/pay/gov-pay-stub/index.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 
+const CONF = require('config');
 const statusCodes = require('http-status-codes');
 const { expect, sinon } = require('test/util/chai');
 const GovPayStub = require('app/steps/pay/gov-pay-stub');
@@ -7,7 +8,7 @@ const GovPayStub = require('app/steps/pay/gov-pay-stub');
 const modulePath = 'app/steps/pay/gov-pay-stub';
 
 describe(modulePath, () => {
-  const currentEnv = process.env.NODE_ENV;
+  const currentEnv = CONF.environment;
   const fakeSteps = { CardPaymentStatus: {} };
   class baseStub {
     constructor() {
@@ -26,7 +27,7 @@ describe(modulePath, () => {
 
   afterEach(() => {
     Object.setPrototypeOf(GovPayStub, previousPrototype);
-    process.env.NODE_ENV = currentEnv;
+    CONF.environment = currentEnv;
   });
 
   it('next step is always the card payment query step', () => {
@@ -52,7 +53,7 @@ describe(modulePath, () => {
 
   it('handler returns 404 in production', () => {
     // Arrange.
-    process.env.NODE_ENV = 'production';
+    CONF.environment = 'production';
     const res = { send: sinon.spy() };
     res.status = sinon.stub().returns(res);
     // Act.

--- a/app/steps/sitemap/index.js
+++ b/app/steps/sitemap/index.js
@@ -4,7 +4,7 @@ const CONF = require('config');
 const buildnoml = require('app/steps/sitemap/buildnoml');
 const runStepHandler = require('app/core/handler/runStepHandler');
 
-const PORT = process.env.PORT || process.env.HTTP_PORT || CONF.http.port;
+const PORT = CONF.http.port || CONF.http.porttactical;
 
 const url = `https://localhost:${PORT}/graph`;
 

--- a/app/steps/start/index.test.js
+++ b/app/steps/start/index.test.js
@@ -46,10 +46,10 @@ describe(modulePath, () => {
         const idamArgs = {
           hostName,
           indexUrl: confIdam.indexUrl,
-          idamApiUrl: process.env.IDAM_API_URL || confIdam.idamApiUrl,
-          idamLoginUrl: process.env.IDAM_LOGIN_URL || confIdam.idamLoginUrl,
-          idamSecret: process.env.IDAM_SECRET || confIdam.idamSecret,
-          idamClientID: process.env.IDAM_CLIENT_ID || confIdam.idamClientID,
+          idamApiUrl: confIdam.idamApiUrl,
+          idamLoginUrl: confIdam.idamLoginUrl,
+          idamSecret: confIdam.idamSecret,
+          idamClientID: confIdam.idamClientID,
           redirectUri
         };
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -1,6 +1,6 @@
 appName: PACKAGES_NAME
 project: PACKAGES_PROJECT
-environment: PACKAGES_ENVIRONMENT
+environment: NODE_ENV
 version: PACKAGES_VERSION
 deployment_env: DEPLOYMENT_ENV
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -21,6 +21,8 @@ services:
   featureToggleApi:
     health: FEATURE_TOGGLE_API_HEALHCHECK_URL
 
+  featureToggleApiUrl: FEATURE_TOGGLE_API_URL
+
   payment:
     baseUrl: PAYMENT_SERVICE_URL
     health: PAYMENT_SERVICE_HEALTHCHECK_URL
@@ -113,3 +115,20 @@ rateLimiter:
 
 applicationInsights:
   instrumentationKey: APPINSIGHTS_INSTRUMENTATIONKEY
+
+http:
+  port: PORT
+  porttactical: HTTP_PORT
+
+idamArgs:
+  idamApiUrl: IDAM_API_URL
+  idamLoginUrl: IDAM_LOGIN_URL
+  idamSecret: IDAM_SECRET
+  idamClientID: IDAM_CLIENT_ID
+  idamTestForename: IDAM_TEST_FORENAME
+  idamTestSurname: IDAM_TEST_SURNAME
+  idamTestUserGroup: IDAM_TEST_USER_GROUP
+  idamTestLevelOfAccess: IDAM_TEST_LEVEL_OF_ACCESS
+  idamTestSupportCreateAccountEndpoint: IDAM_TEST_SUPPORT_CREATE_ACCOUNT_ENDPOINT
+
+defaultEnvironmentNodeEnv: E2E_FRONTEND_NODE_ENV

--- a/test/end-to-end/helpers/featureToggleHelper.js
+++ b/test/end-to-end/helpers/featureToggleHelper.js
@@ -4,7 +4,7 @@ const CONF = require('config');
 let Helper = codecept_helper;
 const { get, features } = require('@hmcts/div-feature-toggle-client')({
   env: process.env.E2E_FRONTEND_NODE_ENV || process.env.NODE_ENV,
-  featureToggleApiUrl: process.env.FEATURE_TOGGLE_API_URL || CONF.services.featureToggleApiUrl
+  featureToggleApiUrl: CONF.services.featureToggleApiUrl
 }).featureToggles;
 let toggleStore = require('test/end-to-end/helpers/featureToggleStore.js');
 
@@ -22,7 +22,7 @@ class FeatureToggleHelper extends Helper {
   getFeatureEnabled(feature, defaultValue, origin = 'other') {
 
     return get(feature, defaultValue || CONF.features[feature], origin, {
-      node_env: process.env.E2E_FRONTEND_NODE_ENV || CONF.defaultEnvironmentNodeEnv
+      node_env: CONF.defaultEnvironmentNodeEnv
     })
       .then(() => {
         return features[feature];

--- a/test/end-to-end/helpers/idamConfigHelper.js
+++ b/test/end-to-end/helpers/idamConfigHelper.js
@@ -3,12 +3,12 @@
 const CONF = require('config');
 
 let args = {
-  idamApiUrl: process.env.IDAM_API_URL || CONF.idamArgs.idamApiUrl,
-  accountsEndpoint: process.env.IDAM_TEST_SUPPORT_CREATE_ACCOUNT_ENDPOINT || CONF.idamArgs.idamTestSupportCreateAccountEndpoint,
-  testForename: process.env.IDAM_TEST_FORENAME || CONF.idamArgs.idamTestForename,
-  testSurname: process.env.IDAM_TEST_SURNAME || CONF.idamArgs.idamTestSurname,
-  testUserGroup: process.env.IDAM_TEST_USER_GROUP || CONF.idamArgs.idamTestUserGroup,
-  testLevelOfAccess: process.env.IDAM_TEST_LEVEL_OF_ACCESS || CONF.idamArgs.idamTestLevelOfAccess
+  idamApiUrl: CONF.idamArgs.idamApiUrl,
+  accountsEndpoint: CONF.idamArgs.idamTestSupportCreateAccountEndpoint,
+  testForename: CONF.idamArgs.idamTestForename,
+  testSurname: CONF.idamArgs.idamTestSurname,
+  testUserGroup: CONF.idamArgs.idamTestUserGroup,
+  testLevelOfAccess: CONF.idamArgs.idamTestLevelOfAccess
 };
 
 let testEmail;


### PR DESCRIPTION
# Description
Changed config determination code checking environment and then config for a value to instead just fetch the equivalent config value, ensuring that the config value could be overridden by a named environment value if present.

Changed usages of process.env.NODE_ENV to instead use config.environment

Fixes # (issue)
DIV-1114

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Unit tests, locally running through application journey

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
