### PR TITLE
Div-2508 Draft should be cleared after error message in Fee Ref Number

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -4,6 +4,7 @@
 		"https://nodesecurity.io/advisories/534",
 		"https://nodesecurity.io/advisories/533",
 		"https://nodesecurity.io/advisories/577",
-		"https://nodesecurity.io/advisories/157"
+		"https://nodesecurity.io/advisories/157",
+    "https://nodesecurity.io/advisories/654"
   ]
 }

--- a/app/middleware/sessions.js
+++ b/app/middleware/sessions.js
@@ -68,7 +68,7 @@ const sessions = module.exports = { // eslint-disable-line no-multi-assign
         cookie: {
           secure: cookieSecure,
           httpOnly: true,
-          domain: req.get('host')
+          domain: req.hostname
         }
       })(req, res, sessionHandled);
     };

--- a/app/services/mocks/feeRegisterService.js
+++ b/app/services/mocks/feeRegisterService.js
@@ -1,7 +1,7 @@
 const mockFeeResponse = {
-  code: 'X0165',
+  code: 'FEE0002',
   description: 'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.',
-  version: 1,
+  version: 4,
   fee_amount: 550.00
 };
 

--- a/app/steps/help/with-fees/index.js
+++ b/app/steps/help/with-fees/index.js
@@ -37,6 +37,10 @@ module.exports = class WithFees extends ValidationStep {
     }
     const [isValid, errors] = super.validate(ctx, session);
 
+    if (ctx.helpWithFeesAppliedForFees === 'No') {
+      delete ctx.helpWithFeesReferenceNumber;
+    }
+
     if (isValid) {
       // format reference number so it includes hyphens and HWF
       if (ctx.helpWithFeesReferenceNumber && ctx.helpWithFeesReferenceNumber.length) {

--- a/app/steps/help/with-fees/index.js
+++ b/app/steps/help/with-fees/index.js
@@ -32,11 +32,10 @@ module.exports = class WithFees extends ValidationStep {
   }
 
   validate(ctx, session) {
-    const [isValid, errors] = super.validate(ctx, session);
-
     if (ctx.helpWithFeesAppliedForFees === 'No') {
       delete ctx.helpWithFeesReferenceNumber;
     }
+    const [isValid, errors] = super.validate(ctx, session);
 
     if (isValid) {
       // format reference number so it includes hyphens and HWF

--- a/app/steps/help/with-fees/index.js
+++ b/app/steps/help/with-fees/index.js
@@ -34,6 +34,10 @@ module.exports = class WithFees extends ValidationStep {
   validate(ctx, session) {
     const [isValid, errors] = super.validate(ctx, session);
 
+    if (ctx.helpWithFeesAppliedForFees === 'No') {
+      delete ctx.helpWithFeesReferenceNumber;
+    }
+
     if (isValid) {
       // format reference number so it includes hyphens and HWF
       if (ctx.helpWithFeesReferenceNumber && ctx.helpWithFeesReferenceNumber.length) {

--- a/app/steps/help/with-fees/index.js
+++ b/app/steps/help/with-fees/index.js
@@ -37,10 +37,6 @@ module.exports = class WithFees extends ValidationStep {
     }
     const [isValid, errors] = super.validate(ctx, session);
 
-    if (ctx.helpWithFeesAppliedForFees === 'No') {
-      delete ctx.helpWithFeesReferenceNumber;
-    }
-
     if (isValid) {
       // format reference number so it includes hyphens and HWF
       if (ctx.helpWithFeesReferenceNumber && ctx.helpWithFeesReferenceNumber.length) {

--- a/app/steps/help/with-fees/index.test.js
+++ b/app/steps/help/with-fees/index.test.js
@@ -67,6 +67,16 @@ describe(modulePath, () => {
         s.steps.ExitNoHelpWithFees);
     });
 
+    it('redirects to the next page when No selected and HWF number not correct', done => {
+      const context = {
+        helpWithFeesAppliedForFees: 'No',
+        helpWithFeesReferenceNumber: 'WrongHWF'
+      };
+
+      testRedirect(done, agent, underTest, context,
+        s.steps.ExitNoHelpWithFees);
+    });
+
     it('redirects to the next page when Yes selected and HWF number correct', done => {
       const context = {
         helpWithFeesAppliedForFees: 'Yes',
@@ -98,16 +108,6 @@ describe(modulePath, () => {
 
       testErrors(done, agent, underTest, context,
         content, 'invalid', ['helpWithFeesReferenceNumber']);
-    });
-
-    it('redirects to the next page when No selected and HWF number uncorrect', done => {
-      const context = {
-        helpWithFeesAppliedForFees: 'No',
-        helpWithFeesReferenceNumber: 'HWF'
-      };
-
-      testRedirect(done, agent, underTest, context,
-        s.steps.ExitNoHelpWithFees);
     });
 
     it('renders errors for providing too short reference number', done => {

--- a/app/steps/help/with-fees/index.test.js
+++ b/app/steps/help/with-fees/index.test.js
@@ -100,6 +100,16 @@ describe(modulePath, () => {
         content, 'invalid', ['helpWithFeesReferenceNumber']);
     });
 
+    it('redirects to the next page when No selected and HWF number uncorrect', done => {
+      const context = {
+        helpWithFeesAppliedForFees: 'No',
+        helpWithFeesReferenceNumber: 'HWF'
+      };
+
+      testRedirect(done, agent, underTest, context,
+        s.steps.ExitNoHelpWithFees);
+    });
+
     it('renders errors for providing too short reference number', done => {
       const context = {
         helpWithFeesAppliedForFees: 'Yes',

--- a/app/steps/help/with-fees/index.test.js
+++ b/app/steps/help/with-fees/index.test.js
@@ -100,16 +100,6 @@ describe(modulePath, () => {
         content, 'invalid', ['helpWithFeesReferenceNumber']);
     });
 
-    it('redirects to the next page when No selected and HWF number uncorrect', done => {
-      const context = {
-        helpWithFeesAppliedForFees: 'No',
-        helpWithFeesReferenceNumber: 'HWF'
-      };
-
-      testRedirect(done, agent, underTest, context,
-        s.steps.ExitNoHelpWithFees);
-    });
-
     it('renders errors for providing too short reference number', done => {
       const context = {
         helpWithFeesAppliedForFees: 'Yes',

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -158,9 +158,8 @@ describe(modulePath, () => {
           const returnUrl = response.request.protocol.concat(
             '//', response.request.host, '/pay/card-payment-status'
           );
-          const DEFAULT_FEE_AMOUNT = 550;
           expect(create.calledWith(
-            {}, 'token', 'some-case-id', 'some-code', 'X0165', 1, DEFAULT_FEE_AMOUNT,
+            {}, 'token', 'some-case-id', 'some-code', code, version, amount,
             'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.',
             returnUrl
           )).to.equal(true);

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -66,10 +66,10 @@ dateFormat: 'DD/MM/YYYY'
 paymentDateFormat: 'DDMMYYYY'
 
 commonProps:
-  applicationFee: 
-    code: 'X0165'
-    description: 'Divorce fee'
-    version: 1
+  applicationFee:
+    code: 'FEE0002'
+    description: 'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.'
+    version: 4
     fee_amount: 550.00
   financialOrderApplicationFee: 255
   court:


### PR DESCRIPTION
Use this PR instead of PR 97
# Description
[DIV-2508 - Draft should be cleared after error message](https://tools.hmcts.net/jira/browse/DIV-2508)

This PR fix this bug. When the user chose Do you have a Help with Fees reference number? No, the application remove from the session  any Fee Reference Number.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually, units

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
