### PR TITLE
send app insight to common location - use the same key

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -41,6 +41,7 @@ module "frontend" {
   ilbIp = "${var.ilbIp}"
   is_frontend = "${var.env != "preview" ? 1: 0}"
   subscription = "${var.subscription}"
+  appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
   additional_host_name = "${var.env != "preview" ? var.additional_host_name : "null"}"
   https_only = "false"
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -20,6 +20,11 @@ variable "env" { }
 
 variable "ilbIp" { }
 
+variable "appinsights_instrumentation_key" {
+    description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
+    default = ""
+}
+
 variable "deployment_env" {
   type = "string"
 }
@@ -31,7 +36,7 @@ variable "deployment_path" {
 variable "node_config_dir" {
   // for Unix
   // default = "/opt/divorce/frontend/config"
-  
+
   // for Windows
   default = "D:\\home\\site\\wwwroot\\config"
 }


### PR DESCRIPTION
# Description

Configured appinsight to use generated telemetric key so all the monitoring can be tracked in one place

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
