### PR TITLE
Div-2259 add desertion max size

### DIFF
--- a/app/middleware/evidenceManagmentMiddleware.js
+++ b/app/middleware/evidenceManagmentMiddleware.js
@@ -92,7 +92,7 @@ const createHandler = nameSpace => {
       return next();
     }
 
-    const bearerToken = `Bearer ${req.cookies['__auth-token']}`;
+    const token = req.cookies['__auth-token'];
 
     // delete file from get link query param `noJsDelete=filename.jpg`
     const method = req.query.noJsDelete ? 'delete' : req.method.toLowerCase();
@@ -120,7 +120,7 @@ const createHandler = nameSpace => {
       return validatePostRequest(req, nameSpace)
         .then(fileManagment.saveFileFromRequest)
         .then(file => {
-          return evidenceManagmentService.sendFile(file, { bearerToken });
+          return evidenceManagmentService.sendFile(file, { token });
         })
         .then(files => {
           return handleResponseFromFileStore(req, res, files, nameSpace);

--- a/app/middleware/evidenceManagmentMiddleware.js
+++ b/app/middleware/evidenceManagmentMiddleware.js
@@ -92,7 +92,7 @@ const createHandler = nameSpace => {
       return next();
     }
 
-    const token = req.cookies['__auth-token'];
+    const bearerToken = `Bearer ${req.cookies['__auth-token']}`;
 
     // delete file from get link query param `noJsDelete=filename.jpg`
     const method = req.query.noJsDelete ? 'delete' : req.method.toLowerCase();
@@ -120,7 +120,7 @@ const createHandler = nameSpace => {
       return validatePostRequest(req, nameSpace)
         .then(fileManagment.saveFileFromRequest)
         .then(file => {
-          return evidenceManagmentService.sendFile(file, { token });
+          return evidenceManagmentService.sendFile(file, { bearerToken });
         })
         .then(files => {
           return handleResponseFromFileStore(req, res, files, nameSpace);

--- a/app/steps/grounds-for-divorce/desertion/details/content.json
+++ b/app/steps/grounds-for-divorce/desertion/details/content.json
@@ -15,7 +15,7 @@
                 "errors": {
                     "reasonForDivorceDesertionDetails": {
                         "required": "Enter a description of how your {{ divorceWho }} deserted you",
-                        "invalid": "Enter a valid description of how your {{ divorceWho }} deserted you"
+                        "invalid": "Enter a valid description of how your {{ divorceWho }} deserted you. Maximum 20000 characters"
                     }
                 }
             }

--- a/app/steps/grounds-for-divorce/desertion/details/schema.json
+++ b/app/steps/grounds-for-divorce/desertion/details/schema.json
@@ -5,6 +5,7 @@
     "properties": {
         "reasonForDivorceDesertionDetails": {
             "type": "string",
+            "maxLength": 20000,
             "minLength": 1
         }
     },


### PR DESCRIPTION
# Description
[DIV-2259 - Desertion details page rendering Too large Payload when i submit Desertion Summary Text size has 20k characters](https://tools.hmcts.net/jira/browse/DIV-2259)

This PR fix this bug. If the desertion details is more than 20000 chars and error message is returned.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually, units

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
