### PR TITLE
Reduce build agent load and speed up e2e tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -18,6 +18,10 @@ withPipeline("nodejs", product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
   }
 
+  before('functionalTest:preview') {
+    env.PREVIEW_ENV = 'true'
+  }
+
   after('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -3,6 +3,7 @@ project: PACKAGES_PROJECT
 environment: PACKAGES_ENVIRONMENT
 version: PACKAGES_VERSION
 deployment_env: DEPLOYMENT_ENV
+env: ENV
 
 service:
   name: SERVICE_NAME

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -3,7 +3,7 @@ project: PACKAGES_PROJECT
 environment: PACKAGES_ENVIRONMENT
 version: PACKAGES_VERSION
 deployment_env: DEPLOYMENT_ENV
-env: ENV
+preview_env: PREVIEW_ENV
 
 service:
   name: SERVICE_NAME

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -66,10 +66,10 @@ exports.config = {
 // Temporarily turn off functional tests in Preview until more stable (#DIV-2734).
 // E2E tests must be run manually against Preview in the meantime.
 function getTests() {
-  console.log('### CONF.env =', CONF.env);  // eslint-disable-line no-console
-  if (CONF.env !== 'preview') {
-    return './paths/**/*.js';
-  } else {
+  console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
+  if (CONF.preview_env === 'true') {
     return './smoke/*.js';
+  } else {
+    return './paths/**/*.js';
   }
 }

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -56,12 +56,22 @@ exports.config = {
   },
   multiple: {
     parallel: {
-      chunks: 2,
+      chunks: configureChunks(),
       browsers: ['chrome']
     }
   },
   name: 'frontend Tests'
 };
+
+// Reduce chunks on Preview env
+function configureChunks() {
+  console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
+  if (CONF.preview_env === 'true') {
+    return 2;
+  } else {
+    return 5;
+  }
+}
 
 // Temporarily turn off functional tests in Preview until more stable (#DIV-2734).
 // E2E tests must be run manually against Preview in the meantime.

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -78,7 +78,7 @@ function configureChunks() {
 function getTests() {
   console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
   if (CONF.preview_env === 'true') {
-    return './smoke/*.js';
+    return './paths/**/basicDivorce.js';
   } else {
     return './paths/**/*.js';
   }

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -14,6 +14,9 @@ exports.config = {
       waitForTimeout,
       waitForAction,
       show: false,
+      restart: false,
+      keepCookies: false,
+      keepBrowserState: false,
       chrome: {
         ignoreHTTPSErrors: true,
         args: [

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-magic-numbers */
+const CONF = require('config');
+
 const waitForTimeout = parseInt(process.env.E2E_WAIT_FOR_TIMEOUT_VALUE) || 10000;
 const waitForAction = parseInt(process.env.E2E_WAIT_FOR_ACTION_VALUE) || 100;
 
@@ -6,7 +8,7 @@ console.log('waitForTimeout value set to', waitForTimeout); // eslint-disable-li
 console.log('waitForAction value set to', waitForAction); // eslint-disable-line no-console
 
 exports.config = {
-  tests: './paths/**/*.js',
+  tests: getTests(),
   output: process.cwd() + '/functional-output',
   helpers: {
     Puppeteer: {
@@ -60,3 +62,14 @@ exports.config = {
   },
   name: 'frontend Tests'
 };
+
+// Temporarily turn off functional tests in Preview until more stable (#DIV-2734).
+// E2E tests must be run manually against Preview in the meantime.
+function getTests() {
+  console.log('### CONF.env =', CONF.env);  // eslint-disable-line no-console
+  if (CONF.env !== 'preview') {
+    return './paths/**/*.js';
+  } else {
+    return './smoke/*.js';
+  }
+}

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -54,55 +54,9 @@ exports.config = {
   },
   multiple: {
     parallel: {
-      chunks: (files) => {
-        let configuredChunks = constructChunksWithFullFilePaths([
-          [ 'jurisdictionConnections.js', 'cookieBanner.js', 'logout.js' ],
-          [ 'payment.js', 'errorPaths.js', 'postcode.js' ],
-          [ 'reasonsForDivorce.js', 'invalidCsrf.js', 'reportAProblemPath.js' ],
-          [ 'livingTogether.js', 'save-resume.js', 'aboutYourMarriageCertificate.js', 'staticPages.js' ],
-          [ 'foreignMarriageCertificates.js', 'basicDivorce.js', 'startSession.js', 'uploadMarriageCertificate.js' ]
-        ], files[0]);
-
-        const leftoverTestFiles = getUndefinedTestFiles(configuredChunks, files[0]);
-        if (leftoverTestFiles.length > 0) {
-          configuredChunks.push([ leftoverTestFiles ]); // add any undefined test files
-        }
-        return configuredChunks;
-      },
+      chunks: 2,
       browsers: ['chrome']
     }
   },
   name: 'frontend Tests'
 };
-
-function getUndefinedTestFiles(chunks, allFiles) {
-  chunks.forEach((chunk)=> {
-    chunk.forEach((testFile) => {
-      const index = allFiles.indexOf(testFile);
-      if(index > -1) { allFiles.splice(index, 1); }
-    });
-  });
-
-  console.log('Undefined Test Files =', allFiles); // eslint-disable-line no-console
-  return allFiles;
-}
-
-function constructChunksWithFullFilePaths(chunks, files) {
-  let finalChunks = [];
-
-  chunks.forEach((chunk) => {
-    let individualChunk = [];
-
-    chunk.forEach((testFile) => {
-
-      const result = files.find((fullFileName) => {
-        return (fullFileName.indexOf(testFile) > -1);
-      });
-      individualChunk.push(result);
-    });
-    finalChunks.push(individualChunk);
-  });
-
-  console.log('All Chunks Configured =', finalChunks); // eslint-disable-line no-console
-  return finalChunks;
-}

--- a/test/end-to-end/paths/aboutYourMarriageCertificate.js
+++ b/test/end-to-end/paths/aboutYourMarriageCertificate.js
@@ -1,6 +1,6 @@
 const content = require('app/steps/marriage/about-your-marriage-certificate/content.json').resources.en.translation.content;
 
-Feature('Foreign Marriage Certificates - Certificate Language', { retries: 1 });
+Feature('Foreign Marriage Certificates - Certificate Language').retry(3);
 
 Scenario('Marriage certificate in English, answered Yes', (I) => {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/basicDivorce.js
+++ b/test/end-to-end/paths/basicDivorce.js
@@ -1,6 +1,6 @@
 const content = require('app/steps/grounds-for-divorce/reason/content.json').resources.en.translation.content;
 
-Feature('Basic divorce path', { retries: 1 });
+Feature('Basic divorce path').retry(3);
 
 Scenario('Get a divorce', function*(I) {
 

--- a/test/end-to-end/paths/cookieBanner.js
+++ b/test/end-to-end/paths/cookieBanner.js
@@ -1,4 +1,4 @@
-Feature('Cookie Banner', { retries: 1 });
+Feature('Cookie Banner').retry(3);
 
 Scenario('The cookie banner displays when page is first hit', function*(I) {
 

--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -1,4 +1,4 @@
-Feature('Invalid Paths Handling', { retries: 1 });
+Feature('Invalid Paths Handling').retry(3);
 
 Scenario('Incorrect URLs are served a 404 page', (I) => {
 

--- a/test/end-to-end/paths/foreignMarriageCertificates.js
+++ b/test/end-to-end/paths/foreignMarriageCertificates.js
@@ -1,4 +1,4 @@
-Feature('Foreign Marriage Certificates', { retries: 1 });
+Feature('Foreign Marriage Certificates').retry(3);
 
 Scenario('Certificate in English ', function(I) {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/invalidCsrf.js
+++ b/test/end-to-end/paths/invalidCsrf.js
@@ -1,4 +1,4 @@
-Feature('Simulated invalid CSRF token', { retries: 1 });
+Feature('Simulated invalid CSRF token').retry(3);
 
 Scenario('Should continue if there is a csrf token set', function* (I) {
 

--- a/test/end-to-end/paths/jurisdictionConnections.js
+++ b/test/end-to-end/paths/jurisdictionConnections.js
@@ -1,4 +1,4 @@
-Feature('New Jurisdiction Journeys', { retries: 1 });
+Feature('New Jurisdiction Journeys').retry(3);
 
 Before((I) => {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/livingTogether.js
+++ b/test/end-to-end/paths/livingTogether.js
@@ -9,7 +9,7 @@ const respondentAddress = {
   postcodeError: 'false'
 };
 
-Feature('Living Together', { retries: 1 });
+Feature('Living Together').retry(3);
 
 Scenario('Petitioner accepts their home address for paper contact', (I) => {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/logout.js
+++ b/test/end-to-end/paths/logout.js
@@ -1,7 +1,7 @@
 const toggleStore = require('test/end-to-end/helpers/featureToggleStore.js');
 const idamConfigHelper = require('test/end-to-end/helpers/idamConfigHelper.js');
 
-Feature('Logout Session', { retries: 1 });
+Feature('Logout Session').retry(3);
 
 Scenario('Logount on Save and close', function (I) {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/payment.js
+++ b/test/end-to-end/paths/payment.js
@@ -3,7 +3,7 @@ const payHelpFeeContent = payHelpContent.explanation.replace('<strong>£{{ appli
 const reasonContent = require('app/steps/grounds-for-divorce/reason/content.json').resources.en.translation.content;
 
 
-Feature('Payment method', { retries: 1 });
+Feature('Payment method').retry(3);
 
 Scenario('Fee displays on /pay/help/need-help page', function (I) {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/postcode.js
+++ b/test/end-to-end/paths/postcode.js
@@ -1,4 +1,4 @@
-Feature('Entering address', { retries: 1 });
+Feature('Entering address').retry(3);
 
 Scenario('Enter address using postcode', (I) => {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/reasonsForDivorce.js
+++ b/test/end-to-end/paths/reasonsForDivorce.js
@@ -15,7 +15,7 @@ const fiveYearsAgoFormatted = {
 };
 
 
-Feature('Reasons for divorce', { retries: 1 });
+Feature('Reasons for divorce').retry(3);
 
 Scenario('Unreasonable behaviour - with added examples', (I) => {
 

--- a/test/end-to-end/paths/reportAProblemPath.js
+++ b/test/end-to-end/paths/reportAProblemPath.js
@@ -4,7 +4,7 @@ const phone = config.get('commonProps.courtPhoneNumber');
 const hours = config.get('commonProps.courtOpeningHour');
 const email = config.get('commonProps.courtEmail');
 
-Feature('Report A Problem Handling', { retries: 1 });
+Feature('Report A Problem Handling').retry(3);
 
 Scenario('I see link to go the ’Report a problem’ page', (I) => {
 

--- a/test/end-to-end/paths/save-resume.js
+++ b/test/end-to-end/paths/save-resume.js
@@ -1,7 +1,7 @@
 const toggleStore = require('test/end-to-end/helpers/featureToggleStore.js');
 const idamConfigHelper = require('test/end-to-end/helpers/idamConfigHelper.js');
 
-Feature('Draft petition store', { retries: 1 });
+Feature('Draft petition store').retry(3);
 
 Scenario('See the check your answers page if session restored from draft petition store', function (I) {
   I.amOnLoadedPage('/index');

--- a/test/end-to-end/paths/startSession.js
+++ b/test/end-to-end/paths/startSession.js
@@ -1,4 +1,4 @@
-Feature('Initiating Session', { retries: 1 });
+Feature('Initiating Session').retry(3);
 
 Scenario('Redirected to /index page when request a session-required page with no session cookies', (I) => {
 

--- a/test/end-to-end/paths/staticPages.js
+++ b/test/end-to-end/paths/staticPages.js
@@ -1,7 +1,7 @@
 const privacyPolicyContent = require('app/steps/privacy-policy/content.json').resources.en.translation.content;
 const termsAndConditionsContent = require('app/steps/terms-and-conditions/content.json').resources.en.translation.content;
 
-Feature('Static Pages', { retries: 1 });
+Feature('Static Pages').retry(3);
 
 Scenario('View the cookies page', (I) => {
 

--- a/test/end-to-end/paths/uploadMarriageCertificate.js
+++ b/test/end-to-end/paths/uploadMarriageCertificate.js
@@ -1,6 +1,6 @@
 const content = require('app/steps/marriage/upload/content.json').resources.en.translation.content;
 
-Feature('Upload Marriage Certificate', { retries: 1 });
+Feature('Upload Marriage Certificate').retry(3);
 
 Scenario('Test upload', function* (I) {
   I.amOnLoadedPage('/index');


### PR DESCRIPTION
# Description

This change includes 3 attempts to reduce load on Jenkins build agents and improve stability by:

1. E2E tests have been reduced to basicDivorce only on PR build pipeline in Preview temporarily, while test stability in Preview env is improved. #DIV-2810 has been raised to revert this behaviour once these tests are stable.

2. Codecept will no longer restart the chromium browser for every e2e test, in a bid to reduce the amount of load on Jenkins and improve test run time. However, it will still clear out cookies and browser cache, so should keep the tests clean.

3. Parallelisation has been reduced from 5 "chunks" (a.k.a. shards) to 2 on Preview env, to reduce the number of Chromium browsers open at any one time.

4. Allows each test to retry up to 3 times to work around environment issues.

Fixes #DIV-2735

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change has been tested locally and works as expected: the same Chromium browser is used per parallel chunk (so 5 browsers opened in total) for all tests. Will also be tested in pipeline.

**Test Configuration**:

* Hardware: Mac
* O/S and version: OSX
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
