### PR TITLE
remove stale cookies on logout

### DIFF
--- a/app/core/steps/DestroySessionStep.js
+++ b/app/core/steps/DestroySessionStep.js
@@ -3,17 +3,17 @@ const idam = require('app/services/idam');
 const initSession = require('app/middleware/initSession');
 
 module.exports = class DestroySessionStep extends Step {
-  * interceptor(ctx, session) {
-    yield new Promise((resolve, reject) => {
-      session.destroy(error => {
-        return error ? reject(error) : resolve();
+  * preResponse(req) {
+    yield new Promise(resolve => {
+      req.session.regenerate(() => {
+        resolve();
       });
     });
-
-    return ctx;
   }
 
   get middleware() {
-    return [idam.logout(), initSession];
+    // on first hit, init session will pass. on second hit (i.e. refresh)
+    // the user will be redirected to index page
+    return [initSession, idam.logout()];
   }
 };

--- a/app/core/steps/DestroySessionStep.test.js
+++ b/app/core/steps/DestroySessionStep.test.js
@@ -1,57 +1,32 @@
 const { expect, sinon } = require('test/util/chai');
 const idam = require('app/services/idam');
 const initSession = require('app/middleware/initSession');
+const co = require('co');
 
 const modulePath = 'app/core/steps/DestroySessionStep';
 const UnderTest = require(modulePath);
 
+const step = new UnderTest();
+
 describe(modulePath, () => {
-  const session = {};
-  const ctx = {};
-  let step = {};
-
-  beforeEach(() => {
-    session.destroy = sinon.stub().callsArgWith(0, null);
-    step = new UnderTest();
-  });
-
-  it('destroys session in its interceptor', () => {
-    // Act.
-    step.interceptor(ctx, session).next();
-    // Assert.
-    expect(session.destroy.called).to.equal(true);
-  });
-
-  it('resolves if session is destroyed without errors', done => {
-    // Act.
-    const output = step.interceptor(ctx, session).next();
-    // Assert.
-    expect(output.value)
-      .to.be.fulfilled
-      .and.notify(done);
-  });
-
-  it('returns logout middleware', () => {
-    const logoutStub = sinon.stub();
-    sinon.stub(idam, 'logout').returns(logoutStub);
-
-    // Act.
-    const output = step.middleware;
-    // Assert.
-    expect(output).to.eql([logoutStub, initSession]);
-
+  it('returns middleware to logout from idam', () => {
+    sinon.stub(idam, 'logout').returns('idamLogout');
+    expect(step.middleware[0]).to.eql(initSession);
+    expect(step.middleware[1]).to.eql(idam.logout());
     idam.logout.restore();
   });
 
-  it('rejects if session destroy returns an error', done => {
-    // Arrange.
-    const destroyError = new Error('some error');
-    session.destroy.callsArgWith(0, destroyError);
-    // Act.
-    const output = step.interceptor(ctx, session).next();
-    // Assert.
-    expect(output.value)
-      .to.be.rejectedWith(destroyError)
-      .and.notify(done);
+  describe('#preResponse', () => {
+    let req = null;
+    beforeEach(done => {
+      req = { session: { regenerate: sinon.stub().callsArg(0) } };
+      co(function* generator() {
+        yield step.preResponse(req);
+      }).then(done, done);
+    });
+
+    it('destroys the session', () => {
+      expect(req.session.regenerate.calledOnce).to.eql(true);
+    });
   });
 });

--- a/app/core/steps/Step.js
+++ b/app/core/steps/Step.js
@@ -138,6 +138,10 @@ module.exports = class Step {
     return [];
   }
 
+  * preResponse(req, res) { // eslint-disable-line no-unused-vars
+    return Promise.resolve();
+  }
+
   * getRequest(req, res) {
     const { session } = req;
 
@@ -160,6 +164,8 @@ module.exports = class Step {
     }
 
     res.locals.session = session;
+
+    yield this.preResponse(req, res);
 
     res.render(this.template);
   }

--- a/app/core/steps/Step.js
+++ b/app/core/steps/Step.js
@@ -138,7 +138,7 @@ module.exports = class Step {
     return [];
   }
 
-  * preResponse(req, res) { // eslint-disable-line no-unused-vars
+  preResponse(req, res) { // eslint-disable-line no-unused-vars
     return Promise.resolve();
   }
 

--- a/app/core/steps/Step.test.js
+++ b/app/core/steps/Step.test.js
@@ -190,6 +190,7 @@ describe(modulePath, () => {
         sinon.spy(stepInstance, 'generateContent');
         sinon.spy(stepInstance, 'interceptor');
         sinon.spy(stepInstance, 'generateFields');
+        sinon.spy(stepInstance, 'preResponse');
         done();
       });
     });
@@ -198,6 +199,7 @@ describe(modulePath, () => {
       stepInstance.generateContent.restore();
       stepInstance.interceptor.restore();
       stepInstance.generateFields.restore();
+      stepInstance.preResponse.restore();
     });
     it('renders the template successfully', done => {
       co(function* generator() {
@@ -207,6 +209,7 @@ describe(modulePath, () => {
         expect(stepInstance.interceptor.calledOnce).to.eql(true);
         expect(stepInstance.generateContent.calledOnce).to.eql(true);
         expect(stepInstance.generateFields.calledOnce).to.eql(true);
+        expect(stepInstance.preResponse.calledOnce).to.eql(true);
         expect(res.render.calledOnce).to.eql(true);
         expect(res.render.calledWith(`${templatePath}/template`)).to.eql(true);
       }).then(done, done);


### PR DESCRIPTION
# Description

[DIV-2498 - Error decrypting Redis when logging on](https://tools.hmcts.net/jira/browse/DIV-2498)

A fix to ensure after login out of the system you are able to login with a different user.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Yes manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
