### PR TITLE
DIV-2794 Do not run app.listen() for unit tests

### DIFF
--- a/app/components/AddressLookupStep/index.test.js
+++ b/app/components/AddressLookupStep/index.test.js
@@ -26,10 +26,6 @@ describe(modulePath, () => {
     agent = request.agent(s.app);
   });
 
-  afterEach(() => {
-    s.http.close();
-  });
-
   describe('selecting an address via the postcode service', () => {
     let session = {};
 

--- a/app/middleware/draftPetitionStoreMiddleware.test.js
+++ b/app/middleware/draftPetitionStoreMiddleware.test.js
@@ -23,10 +23,6 @@ describe(modulePath, () => {
     checkYourAnswersUrl = s.steps.CheckYourAnswers.url;
   });
 
-  after(() => {
-    s.http.close();
-  });
-
   beforeEach(() => {
     featureTogglesMock.stub();
   });

--- a/app/services/featureToggleList.test.js
+++ b/app/services/featureToggleList.test.js
@@ -13,10 +13,6 @@ describe(modulePath, () => {
       s = server.init();
     });
 
-    afterEach(() => {
-      s.http.close();
-    });
-
     it('should return success', done => {
       //  note that the features (idam) are hardcoded into the app.js
 
@@ -51,7 +47,6 @@ describe(modulePath, () => {
     });
 
     afterEach(() => {
-      s.http.close();
       if (!idam) delete process.env.idam;
     });
 
@@ -88,7 +83,6 @@ describe(modulePath, () => {
 
     afterEach(() => {
       CONF.features = features;
-      s.http.close();
     });
 
     it('should return success', done => {

--- a/app/steps/application-submitted/index.test.js
+++ b/app/steps/application-submitted/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ApplicationSubmitted;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);

--- a/app/steps/authenticated/index.test.js
+++ b/app/steps/authenticated/index.test.js
@@ -31,7 +31,6 @@ describe(modulePath, () => {
 
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
     featureTogglesMock.restore();
     idam.landingPage.restore();

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -29,7 +29,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/done-and-submitted/index.test.js
+++ b/app/steps/done-and-submitted/index.test.js
@@ -24,9 +24,7 @@ describe(modulePath, () => {
     underTest = s.steps.DoneAndSubmitted;
   });
 
-
   afterEach(() => {
-    s.http.close();
     featureTogglesMock.restore();
   });
 

--- a/app/steps/error-400/index.test.js
+++ b/app/steps/error-400/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.Error400;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/error-404/index.test.js
+++ b/app/steps/error-404/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.Error404;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/error-500/index.test.js
+++ b/app/steps/error-500/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.Error500;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/error-generic/index.test.js
+++ b/app/steps/error-generic/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.GenericError;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/exit/about-your-marriage/no-certificate-translated/index.test.js
+++ b/app/steps/exit/about-your-marriage/no-certificate-translated/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitJurisdiction;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/exit/grounds-for-divorce/desertion/agree/index.test.js
+++ b/app/steps/exit/grounds-for-divorce/desertion/agree/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitDesertionAgree;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     let session = {};
 

--- a/app/steps/exit/grounds-for-divorce/desertion/date/index.test.js
+++ b/app/steps/exit/grounds-for-divorce/desertion/date/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitDesertionDate;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     let session = {};
 

--- a/app/steps/exit/grounds-for-divorce/separation/index.test.js
+++ b/app/steps/exit/grounds-for-divorce/separation/index.test.js
@@ -19,12 +19,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitSeparation;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     let session = {};
 

--- a/app/steps/exit/help/with-fees/index.test.js
+++ b/app/steps/exit/help/with-fees/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitNoHelpWithFees;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/exit/jurisdiction/last-resort/index.test.js
+++ b/app/steps/exit/jurisdiction/last-resort/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitJurisdiction;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/exit/jurisdiction/no-connections/index.test.js
+++ b/app/steps/exit/jurisdiction/no-connections/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitNoConnections;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/exit/screening-questions/has-marriage-broken/index.test.js
+++ b/app/steps/exit/screening-questions/has-marriage-broken/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitMarriageBroken;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);

--- a/app/steps/exit/screening-questions/has-marriage-cert/index.test.js
+++ b/app/steps/exit/screening-questions/has-marriage-cert/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitMarriageCertificate;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);

--- a/app/steps/exit/screening-questions/has-respondent-address/index.test.js
+++ b/app/steps/exit/screening-questions/has-respondent-address/index.test.js
@@ -18,12 +18,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitRespondentAddress;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     let session = {};
 

--- a/app/steps/exit/screening-questions/marriage-date/index.test.js
+++ b/app/steps/exit/screening-questions/marriage-date/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitMarriageDate;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);

--- a/app/steps/financial/advice/index.test.js
+++ b/app/steps/financial/advice/index.test.js
@@ -19,12 +19,9 @@ describe(modulePath, () => {
     underTest = s.steps.FinancialAdvice;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/financial/arrangements/index.test.js
+++ b/app/steps/financial/arrangements/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.FinancialArrangements;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/adultery/3rd-party/address/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/3rd-party/address/index.test.js
@@ -24,10 +24,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/adultery/3rd-party/details/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/3rd-party/details/index.test.js
@@ -27,10 +27,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/adultery/details/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/details/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.AdulteryDetails;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success if petitioner does not know when or where', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/adultery/when/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/when/index.test.js
@@ -28,12 +28,9 @@ describe(modulePath, () => {
     underTest = s.steps.AdulteryWhen;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/adultery/where/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/where/index.test.js
@@ -28,12 +28,9 @@ describe(modulePath, () => {
     underTest = s.steps.AdulteryWhere;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/adultery/wish-to-name/index.test.js
+++ b/app/steps/grounds-for-divorce/adultery/wish-to-name/index.test.js
@@ -26,9 +26,7 @@ describe(modulePath, () => {
     underTest = s.steps.AdulteryWishToName;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/grounds-for-divorce/desertion/agree/index.test.js
+++ b/app/steps/grounds-for-divorce/desertion/agree/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.DesertionAgree;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/desertion/details/index.test.js
+++ b/app/steps/grounds-for-divorce/desertion/details/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.DesertionDetails;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/desertion/when-left/index.test.js
+++ b/app/steps/grounds-for-divorce/desertion/when-left/index.test.js
@@ -28,12 +28,9 @@ describe(modulePath, () => {
     underTest = s.steps.DesertionDate;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/reason/index.test.js
+++ b/app/steps/grounds-for-divorce/reason/index.test.js
@@ -33,12 +33,9 @@ describe(modulePath, () => {
     underTest = s.steps.ReasonForDivorce;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('error messages', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/separation-date/index.test.js
+++ b/app/steps/grounds-for-divorce/separation-date/index.test.js
@@ -27,12 +27,9 @@ describe(modulePath, () => {
     underTest = s.steps.SeparationDate;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/grounds-for-divorce/unreasonable-behaviour/index.test.js
+++ b/app/steps/grounds-for-divorce/unreasonable-behaviour/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.UnreasonableBehaviour;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/help/need-help/index.test.js
+++ b/app/steps/help/need-help/index.test.js
@@ -27,9 +27,7 @@ describe(modulePath, () => {
     underTest = s.steps.NeedHelpWithFees;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
     applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
   });

--- a/app/steps/help/with-fees/index.test.js
+++ b/app/steps/help/with-fees/index.test.js
@@ -25,9 +25,7 @@ describe(modulePath, () => {
     underTest = s.steps.WithFees;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/index/index.test.js
+++ b/app/steps/index/index.test.js
@@ -25,9 +25,7 @@ describe(modulePath, () => {
     underTest = s.steps.Index;
   });
 
-
   afterEach(() => {
-    s.http.close();
     featureTogglesMock.restore();
     applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();
   });

--- a/app/steps/jurisdiction/connection-summary/index.test.js
+++ b/app/steps/jurisdiction/connection-summary/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionConnectionSummary;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('JurisdictionConnectionSummary step content for connection A', () => {
     let session = {};

--- a/app/steps/jurisdiction/domicile/index.test.js
+++ b/app/steps/jurisdiction/domicile/index.test.js
@@ -21,12 +21,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionDomicile;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('Domicile step content', () => {
     let session = {};

--- a/app/steps/jurisdiction/habitual-residence/index.test.js
+++ b/app/steps/jurisdiction/habitual-residence/index.test.js
@@ -23,12 +23,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionHabitualResidence;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('Habitual residence step content', () => {
     let session = {};

--- a/app/steps/jurisdiction/interstitial/index.test.js
+++ b/app/steps/jurisdiction/interstitial/index.test.js
@@ -23,12 +23,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionInterstitial;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('JurisdictionInterstitial step content for connection A (both habitually resident)', () => {
     let session = {};

--- a/app/steps/jurisdiction/jurisdiction.allscenarios.test.js
+++ b/app/steps/jurisdiction/jurisdiction.allscenarios.test.js
@@ -283,7 +283,6 @@ describe.skip(`${modulePath} - Test every possible scenario`, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/jurisdiction/jurisdiction.component.test.js
+++ b/app/steps/jurisdiction/jurisdiction.component.test.js
@@ -35,9 +35,7 @@ describe(modulePath, () => {
     agent = request.agent(s.app);
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/jurisdiction/last-habitual-residence/index.test.js
+++ b/app/steps/jurisdiction/last-habitual-residence/index.test.js
@@ -22,12 +22,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionLastHabitualResidence;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('Last Habitual residence step content', () => {
     let session = {};

--- a/app/steps/jurisdiction/last-resort/index.test.js
+++ b/app/steps/jurisdiction/last-resort/index.test.js
@@ -24,9 +24,7 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionLastResort;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/jurisdiction/last-six-months/index.test.js
+++ b/app/steps/jurisdiction/last-six-months/index.test.js
@@ -21,12 +21,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionLastSixMonths;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('Six months content step content', () => {
     let session = {};

--- a/app/steps/jurisdiction/last-twelve-months/index.test.js
+++ b/app/steps/jurisdiction/last-twelve-months/index.test.js
@@ -21,12 +21,9 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionLastTwelveMonths;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/jurisdiction/residual/index.test.js
+++ b/app/steps/jurisdiction/residual/index.test.js
@@ -22,9 +22,7 @@ describe(modulePath, () => {
     underTest = s.steps.JurisdictionResidual;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/legal/legal-proceedings/index.test.js
+++ b/app/steps/legal/legal-proceedings/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.LegalProceedings;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/living-arrangements/last-lived-together/address/index.test.js
+++ b/app/steps/living-arrangements/last-lived-together/address/index.test.js
@@ -23,7 +23,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/living-arrangements/last-lived-together/at-petitioner-home-address/index.test.js
+++ b/app/steps/living-arrangements/last-lived-together/at-petitioner-home-address/index.test.js
@@ -26,9 +26,7 @@ describe(modulePath, () => {
     underTest = s.steps.LastLivedTogether;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/living-arrangements/live-together/index.test.js
+++ b/app/steps/living-arrangements/live-together/index.test.js
@@ -27,12 +27,9 @@ describe(modulePath, () => {
     underTest = s.steps.LiveTogether;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/marriage/about-your-marriage-certificate/index.test.js
+++ b/app/steps/marriage/about-your-marriage-certificate/index.test.js
@@ -25,12 +25,9 @@ describe(modulePath, () => {
     underTest = s.steps.AboutYourMarriageCertificate;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('About your marriage certificate step content', () => {
     const session = {};

--- a/app/steps/marriage/certificate-names/index.test.js
+++ b/app/steps/marriage/certificate-names/index.test.js
@@ -24,10 +24,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('content when certificate is in English', () => {
     let session = {};

--- a/app/steps/marriage/date/index.test.js
+++ b/app/steps/marriage/date/index.test.js
@@ -30,13 +30,10 @@ describe(modulePath, () => {
     stepUnderTest = s.steps.MarriageDate;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
     featureTogglesMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/marriage/foreign-certificate/index.test.js
+++ b/app/steps/marriage/foreign-certificate/index.test.js
@@ -28,7 +28,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/marriage/husband-or-wife/index.test.js
+++ b/app/steps/marriage/husband-or-wife/index.test.js
@@ -22,12 +22,9 @@ describe(modulePath, () => {
     underTest = s.steps.MarriageHusbandOrWife;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/marriage/in-the-uk/index.test.js
+++ b/app/steps/marriage/in-the-uk/index.test.js
@@ -26,7 +26,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
     featureTogglesMock.restore();
   });

--- a/app/steps/marriage/names/index.test.js
+++ b/app/steps/marriage/names/index.test.js
@@ -24,10 +24,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('content', () => {
     let session = {};

--- a/app/steps/marriage/upload/index.test.js
+++ b/app/steps/marriage/upload/index.test.js
@@ -36,7 +36,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/pay/card-payment-status/index.test.js
+++ b/app/steps/pay/card-payment-status/index.test.js
@@ -54,8 +54,6 @@ describe(modulePath, () => {
     submission.setup.restore();
     serviceToken.setup.restore();
     idam.userDetails.restore();
-
-    s.http.close();
     featureTogglesMock.restore();
     idamMock.restore();
   });

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -52,7 +52,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
     featureTogglesMock.restore();
     applicationFeeMiddleware.updateApplicationFeeMiddleware.restore();

--- a/app/steps/petitioner/changed-name/index.test.js
+++ b/app/steps/petitioner/changed-name/index.test.js
@@ -26,10 +26,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('content', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/petitioner/confidential/index.test.js
+++ b/app/steps/petitioner/confidential/index.test.js
@@ -23,12 +23,9 @@ describe(modulePath, () => {
     underTest = s.steps.PetitionerConfidential;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     beforeEach(done => {

--- a/app/steps/petitioner/contact-details/index.test.js
+++ b/app/steps/petitioner/contact-details/index.test.js
@@ -26,7 +26,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/petitioner/correspondence/address/index.test.js
+++ b/app/steps/petitioner/correspondence/address/index.test.js
@@ -25,7 +25,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/petitioner/correspondence/use-home-address/index.test.js
+++ b/app/steps/petitioner/correspondence/use-home-address/index.test.js
@@ -24,12 +24,9 @@ describe(modulePath, () => {
     underTest = s.steps.PetitionerCorrespondence;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     beforeEach(done => {

--- a/app/steps/petitioner/home/address/index.test.js
+++ b/app/steps/petitioner/home/address/index.test.js
@@ -23,7 +23,6 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 

--- a/app/steps/prayer/claim-costs/index.test.js
+++ b/app/steps/prayer/claim-costs/index.test.js
@@ -28,13 +28,11 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
 
   describe('content', () => {
     let session = {};
-
 
     describe('when Help with fees refference number exists', () => {
       beforeEach(done => {

--- a/app/steps/privacy-policy/index.test.js
+++ b/app/steps/privacy-policy/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.PrivacyPolicy;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/respondent/correspondence/address/index.test.js
+++ b/app/steps/respondent/correspondence/address/index.test.js
@@ -21,10 +21,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/correspondence/send-to-solicitor/index.test.js
+++ b/app/steps/respondent/correspondence/send-to-solicitor/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.RespondentCorrespondenceSendToSolicitor;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/correspondence/use-home-address/index.test.js
+++ b/app/steps/respondent/correspondence/use-home-address/index.test.js
@@ -23,12 +23,9 @@ describe(modulePath, () => {
     underTest = s.steps.RespondentCorrespondenceUseHomeAddress;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/home/address/index.test.js
+++ b/app/steps/respondent/home/address/index.test.js
@@ -24,10 +24,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/home/is-known/index.test.js
+++ b/app/steps/respondent/home/is-known/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.RespondentHomeAddressIsKnown;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/home/lives-at-last-address/index.test.js
+++ b/app/steps/respondent/home/lives-at-last-address/index.test.js
@@ -26,12 +26,9 @@ describe(modulePath, () => {
     underTest = s.steps.RespondentLivesAtLastAddress;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/solicitor/address/index.test.js
+++ b/app/steps/respondent/solicitor/address/index.test.js
@@ -21,10 +21,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/respondent/solicitor/details/index.test.js
+++ b/app/steps/respondent/solicitor/details/index.test.js
@@ -28,10 +28,8 @@ describe(modulePath, () => {
   });
 
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     let session = {};

--- a/app/steps/save-resume/confirm-remove-saved-application/index.test.js
+++ b/app/steps/save-resume/confirm-remove-saved-application/index.test.js
@@ -19,12 +19,6 @@ describe(modulePath, () => {
     underTest = s.steps.DeleteApplication;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);

--- a/app/steps/save-resume/removed-saved-application/index.test.js
+++ b/app/steps/save-resume/removed-saved-application/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitRemovedSavedApplication;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);

--- a/app/steps/save-resume/save-and-close/index.test.js
+++ b/app/steps/save-resume/save-and-close/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.ExitApplicationSaved;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/app/steps/screening-questions/has-marriage-broken/index.test.js
+++ b/app/steps/screening-questions/has-marriage-broken/index.test.js
@@ -20,12 +20,9 @@ describe(modulePath, () => {
     underTest = s.steps.ScreeningQuestionsMarriageBroken;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/screening-questions/has-marriage-cert/index.test.js
+++ b/app/steps/screening-questions/has-marriage-cert/index.test.js
@@ -18,12 +18,9 @@ describe(modulePath, () => {
     underTest = s.steps.ScreeningQuestionsMarriageCertificate;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/screening-questions/has-respondent-address/index.test.js
+++ b/app/steps/screening-questions/has-respondent-address/index.test.js
@@ -19,12 +19,9 @@ describe(modulePath, () => {
     underTest = s.steps.ScreeningQuestionsRespondentAddress;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamMock.restore();
   });
-
 
   describe('success', () => {
     it('renders the content from the content file', done => {

--- a/app/steps/sitemap/index.test.js
+++ b/app/steps/sitemap/index.test.js
@@ -5,7 +5,7 @@ const statusCode = require('app/core/utils/statusCode');
 
 describe(__filename, () => {
   it('renders sitemap when config.showSitemap is true', async () => {
-    const { app, http } = server.init();
+    const { app } = server.init();
     const showSitemap = config.showSitemap;
 
     config.showSitemap = true;
@@ -15,11 +15,10 @@ describe(__filename, () => {
       .expect(statusCode.OK);
 
     config.showSitemap = showSitemap;
-    return http.close();
   });
 
   it('redirects to 404 when config.showSitemap is false', async () => {
-    const { app, http } = server.init();
+    const { app } = server.init();
     const showSitemap = config.showSitemap;
     config.showSitemap = false;
 
@@ -29,6 +28,5 @@ describe(__filename, () => {
       .expect('Location', '/errors/404');
 
     config.showSitemap = showSitemap;
-    return http.close();
   });
 });

--- a/app/steps/start/index.test.js
+++ b/app/steps/start/index.test.js
@@ -23,12 +23,9 @@ describe(modulePath, () => {
     underTest = s.steps.Start;
   });
 
-
   afterEach(() => {
-    s.http.close();
     idamExpressMiddleware.authenticate.restore();
   });
-
 
   describe('success', () => {
     it('should immediately redirect to the has marriage broken step page if authenticated', done => {

--- a/app/steps/submit/index.test.js
+++ b/app/steps/submit/index.test.js
@@ -41,8 +41,6 @@ describe(modulePath, () => {
 
   afterEach(() => {
     submission.setup.restore();
-
-    s.http.close();
     featureTogglesMock.restore();
     idamMock.restore();
   });

--- a/app/steps/terms-and-conditions/index.test.js
+++ b/app/steps/terms-and-conditions/index.test.js
@@ -17,12 +17,6 @@ describe(modulePath, () => {
     underTest = s.steps.TermsAndConditions;
   });
 
-
-  afterEach(() => {
-    s.http.close();
-  });
-
-
   describe('success', () => {
     const session = {};
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 const appInsights = require('applicationinsights');
 const CONF = require('config');
 
+const listenForConnections = true;
+
 if (CONF.applicationInsights.instrumentationKey) {
   appInsights.setup(CONF.applicationInsights.instrumentationKey)
     .setAutoCollectConsole(true, true)
@@ -9,7 +11,7 @@ if (CONF.applicationInsights.instrumentationKey) {
 
 const app = require('./app');
 
-const { http } = app.init();
+const { http } = app.init(listenForConnections);
 
 process.on('SIGTERM', () => {
   http.close(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,9 +124,9 @@
     request "^2.81.0"
     request-promise-native "^1.0.5"
 
-"@hmcts/div-service-auth-provider-client@https://github.com/hmcts/div-service-auth-provider-client#2.1.4":
-  version "2.1.4"
-  resolved "https://github.com/hmcts/div-service-auth-provider-client#b01b4bca71756638a867689a906ed7483d8c8b39"
+"@hmcts/div-service-auth-provider-client@https://github.com/hmcts/div-service-auth-provider-client#3.0.0":
+  version "3.0.0"
+  resolved "https://github.com/hmcts/div-service-auth-provider-client#82ac790f04376ed26691eb012ca72a092e5bd00d"
   dependencies:
     jsonwebtoken "^8.0.1"
     otp "^0.1.3"


### PR DESCRIPTION
# Description

Frequently seeing the 'test' step of pipeline build fail due to:

`Uncaught Error: listen EADDRINUSE :::3001`

This is likely due to the asynchronous nature ofthe Node.js `http.close()` method but it's not necessary for our Supertest.js tests to initialise listening for connections, so simplest and safest not to initialise `app.listen()` when testing that way.

Fixes # DIV-2794

# Checklist:

- [x] New and existing unit tests pass locally with my changes

**n.b.** tests may still fail in other difficult to reproduce ways but this is part of a wider epic.