### PR TITLE
Comment out url for feature-toggle-api and use configs

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,8 +17,8 @@ const manifest = require('manifest.json');
 const helmet = require('helmet');
 const csurf = require('csurf');
 const { fetchToggles } = require('@hmcts/div-feature-toggle-client')({
-  env: CONF.environment,
-  featureToggleApiUrl: CONF.services.featureToggleApiUrl
+  env: CONF.environment
+  // featureToggleApiUrl: CONF.services.featureToggleApiUrl
 });
 const i18nTemplate = require('app/core/utils/i18nTemplate')({
   viewDirectory: './app/views/',

--- a/app/services/healthcheck.js
+++ b/app/services/healthcheck.js
@@ -59,17 +59,6 @@ router.get('/health', healthcheck.configure({
         return !error && res.status === OK ? outputs.up() : outputs.down(error);
       }
     }, options),
-    'feature-toggle-api': healthcheck.web(config.services.featureToggleApi.health, {
-      callback: (error, res) => { // eslint-disable-line id-blacklist
-        if (error) {
-          logger.error({
-            message: 'Health check failed on feature-toggle-api:',
-            error
-          });
-        }
-        return !error && res.status === OK ? outputs.up() : outputs.down(error);
-      }
-    }, options),
     'evidence-management-client-api': healthcheck.web(config.evidenceManagmentClient.health, {
       callback: (error, res) => { // eslint-disable-line id-blacklist
         if (error) {

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -123,6 +123,9 @@ http:
   port: PORT
   porttactical: HTTP_PORT
 
+features:
+  idam: FEATURE_IDAM
+
 idamArgs:
   idamApiUrl: IDAM_API_URL
   idamLoginUrl: IDAM_LOGIN_URL

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "TBD"
 
-rediscloud_url = "betaPreProddivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"
 
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "TBD"
 
-rediscloud_url = "betaPreProddivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"
 
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -126,7 +126,7 @@ module "frontend" {
     POST_CODE_ACCESS_TOKEN = "${data.vault_generic_secret.post_code_token.data["value"]}"
 
     // Redis Cloud
-REDISCLOUD_URL = "redis://ignore:${urlencode(module.redis-cache.access_key)}@${module.redis-cache.host_name}:${module.redis-cache.redis_port}?tls=true"
+    REDISCLOUD_URL = "redis://ignore:${urlencode(module.redis-cache.access_key)}@${module.redis-cache.host_name}:${module.redis-cache.redis_port}?tls=true"
     USE_AUTH       = "${var.use_auth}"
 
     // Encryption secrets

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -102,7 +102,7 @@ module "frontend" {
     FEATURE_TOGGLE_API_HEALHCHECK_URL = "${var.feature_toggle_api_url}${var.health_endpoint}"
     jurisdiction                      = "${var.feature_jurisdiction}"
     newJurisdiction                   = "${var.feature_new_jurisdiction}"
-    feature_idam                      = "${var.feature_idam}"
+    FEATURE_IDAM                      = "${var.feature_idam}"
     foreignMarriageCerts              = "${var.feature_foreign_marriage_certs}"
     courtSouthampton                  = "${var.feature_court_southamption}"
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -36,6 +36,14 @@ locals {
   status_health_endpoint             = "/status/health"
 }
 
+module "redis-cache" {
+  source   = "git@github.com:hmcts/moj-module-redis?ref=master"
+  product  = "${var.env != "preview" ? "${var.product}-redis" : "${var.product}-${var.reform_service_name}-redis"}"
+  location = "${var.location}"
+  env      = "${var.env}"
+  subnetid = "${data.terraform_remote_state.core_apps_infrastructure.subnet_ids[1]}"
+}
+
 module "frontend" {
   source                          = "git@github.com:hmcts/moj-module-webapp.git?ref=master"
   product                         = "${var.product}-${var.reform_service_name}"
@@ -118,7 +126,7 @@ module "frontend" {
     POST_CODE_ACCESS_TOKEN = "${data.vault_generic_secret.post_code_token.data["value"]}"
 
     // Redis Cloud
-    REDISCLOUD_URL = "${var.rediscloud_url}"
+REDISCLOUD_URL = "redis://ignore:${urlencode(module.redis-cache.access_key)}@${module.redis-cache.host_name}:${module.redis-cache.redis_port}?tls=true"
     USE_AUTH       = "${var.use_auth}"
 
     // Encryption secrets

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -102,7 +102,7 @@ module "frontend" {
     FEATURE_TOGGLE_API_HEALHCHECK_URL = "${var.feature_toggle_api_url}${var.health_endpoint}"
     jurisdiction                      = "${var.feature_jurisdiction}"
     newJurisdiction                   = "${var.feature_new_jurisdiction}"
-    idam                              = "${var.feature_idam}"
+    feature_idam                      = "${var.feature_idam}"
     foreignMarriageCerts              = "${var.feature_foreign_marriage_certs}"
     courtSouthampton                  = "${var.feature_court_southamption}"
 

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -9,3 +9,7 @@ output "feature_toggle_api_url" {
 output "case_progression_service_draft_url" {
   value = "${local.case_progression_service_url}${var.draft_store_api_base_path}"
 }
+
+output "feature_idam" {
+  value = "${var.feature_idam}"
+}

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "TBD"
 
-rediscloud_url = "betaPreProddivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"
 
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "UA-93824767-3"
 
-rediscloud_url = "betaProddivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://hmcts-access.service.gov.uk"
 
 idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/saat.tfvars
+++ b/infrastructure/saat.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "TBD"
 
-rediscloud_url = "betaDevBdivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://idam-test.dev.ccidam.reform.hmcts.net"
 
 idam_api_url = "http://betaDevBccidamAppLB.reform.hmcts.net:80"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "TBD"
 
-rediscloud_url = "betaDevBdivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://idam-test.dev.ccidam.reform.hmcts.net"
 
 idam_api_url = "http://betaDevBccidamAppLB.reform.hmcts.net:80"

--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -12,8 +12,6 @@ http_proxy = ""
 
 google_analytics_tracking_id = "UA-93824767-2"
 
-rediscloud_url = "betaDevBdivorceCache01.reform.hmcts.net:6379"
-
 idam_authentication_web_url = "https://idam-test.dev.ccidam.reform.hmcts.net"
 
 idam_api_url = "http://betaDevBccidamAppLB.reform.hmcts.net:80"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -228,7 +228,7 @@ variable "feature_new_jurisdiction" {
 }
 
 variable "feature_idam" {
-  default = false
+  default = true
 }
 
 variable "feature_foreign_marriage_certs" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -115,10 +115,6 @@ variable "google_analytics_tracking_url" {
   default = "http://www.google-analytics.com/collect"
 }
 
-variable "rediscloud_url" {
-  type = "string"
-}
-
 variable "use_auth" {
   default = false
 }


### PR DESCRIPTION
Temporary quick fix so that we don't get issues when tactical env goes does again.

Removes feature-toggle-api healthcheck (since we ave commented out using that url) and also changes redis url from tactical to cnp.