### PR TITLE
Update to latest idamExpressTestHarness for benefit of running tests locally against Preview

### DIFF
--- a/bin/run-functional-tests-local.sh
+++ b/bin/run-functional-tests-local.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+# Extra default details needed during a local test run
+export E2E_FRONTEND_URL=${TEST_URL}
+export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"proxyout.reform.hmcts.net:8080"}
+export E2E_PROXY_BYPASS=${E2E_PROXY_BYPASS:-"*beta*LB.reform.hmcts.net"}
+
+./bin/run-functional-tests.sh

--- a/bin/run-functional-tests-local.sh
+++ b/bin/run-functional-tests-local.sh
@@ -4,6 +4,6 @@ set -ex
 # Extra default details needed during a local test run against CNP environment
 export E2E_FRONTEND_URL=${TEST_URL}
 export FEATURE_IDAM=${FEATURE_IDAM:-"true"}
-export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"socks5://localhost:9000"}
+export E2E_IDAM_PROXY=${E2E_IDAM_PROXY:-"socks5://localhost:9000"}
 
 ./bin/run-functional-tests.sh

--- a/bin/run-functional-tests-local.sh
+++ b/bin/run-functional-tests-local.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -ex
 
-# Extra default details needed during a local test run
+# Extra default details needed during a local test run against CNP environment
 export E2E_FRONTEND_URL=${TEST_URL}
-export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"proxyout.reform.hmcts.net:8080"}
-export E2E_PROXY_BYPASS=${E2E_PROXY_BYPASS:-"*beta*LB.reform.hmcts.net"}
+export FEATURE_IDAM=${FEATURE_IDAM:-"true"}
+export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"socks5://localhost:9000"}
 
 ./bin/run-functional-tests.sh

--- a/bin/run-functional-tests.sh
+++ b/bin/run-functional-tests.sh
@@ -3,8 +3,6 @@ set -ex
 
 # Setup required environment variables. TEST_URL should be set by CNP
 export E2E_FRONTEND_URL=${TEST_URL}
-export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"proxyout.reform.hmcts.net:8080"}
-export E2E_PROXY_BYPASS=${E2E_PROXY_BYPASS:-"*beta*LB.reform.hmcts.net"}
 export E2E_FRONTEND_NODE_ENV=${E2E_FRONTEND_NODE_ENV:-"production"}
 export IDAM_API_URL=${IDAM_API_URL:-"https://preprod-idamapi.reform.hmcts.net:3511"}
 export COURT_PHONENUMBER=${COURT_PHONENUMBER:-"0300 303 0642"}

--- a/bin/run-functional-tests.sh
+++ b/bin/run-functional-tests.sh
@@ -3,10 +3,10 @@ set -ex
 
 # Setup required environment variables. TEST_URL should be set by CNP
 export E2E_FRONTEND_URL=${TEST_URL}
-export E2E_FRONTEND_NODE_ENV=${E2E_FRONTEND_NODE_ENV:-"production"}
-export IDAM_API_URL=${IDAM_API_URL:-"https://preprod-idamapi.reform.hmcts.net:3511"}
 export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"proxyout.reform.hmcts.net:8080"}
 export E2E_PROXY_BYPASS=${E2E_PROXY_BYPASS:-"*beta*LB.reform.hmcts.net"}
+export E2E_FRONTEND_NODE_ENV=${E2E_FRONTEND_NODE_ENV:-"production"}
+export IDAM_API_URL=${IDAM_API_URL:-"https://preprod-idamapi.reform.hmcts.net:3511"}
 export COURT_PHONENUMBER=${COURT_PHONENUMBER:-"0300 303 0642"}
 export COURT_OPENINGHOURS=${COURT_OPENINGHOURS:-"Monday to Friday, 8.30am to 5pm"}
 export COURT_EMAIL=${COURT_EMAIL:-"divorce@justice.gov.uk"}

--- a/bin/run-functional-tests.sh
+++ b/bin/run-functional-tests.sh
@@ -5,6 +5,8 @@ set -ex
 export E2E_FRONTEND_URL=${TEST_URL}
 export E2E_FRONTEND_NODE_ENV=${E2E_FRONTEND_NODE_ENV:-"production"}
 export IDAM_API_URL=${IDAM_API_URL:-"https://preprod-idamapi.reform.hmcts.net:3511"}
+export E2E_PROXY_SERVER=${E2E_PROXY_SERVER:-"proxyout.reform.hmcts.net:8080"}
+export E2E_PROXY_BYPASS=${E2E_PROXY_BYPASS:-"*beta*LB.reform.hmcts.net"}
 export COURT_PHONENUMBER=${COURT_PHONENUMBER:-"0300 303 0642"}
 export COURT_OPENINGHOURS=${COURT_OPENINGHOURS:-"Monday to Friday, 8.30am to 5pm"}
 export COURT_EMAIL=${COURT_EMAIL:-"divorce@justice.gov.uk"}

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "yarn": "^1.5.1"
   },
   "devDependencies": {
-    "@hmcts/div-idam-test-harness": "https://github.com/hmcts/div-idam-test-harness#1.0.12",
+    "@hmcts/div-idam-test-harness": "https://github.com/hmcts/div-idam-test-harness#1.1.0",
     "@hmcts/eslint-config": "^1.0.5",
     "babel-core": "6.26.3",
     "babel-loader": "7.1.4",

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -79,6 +79,6 @@ function getTests() {
   if (CONF.preview_env === 'true') {
     return './paths/**/basicDivorce.js';
   } else {
-    return './paths/**/logout.js';
+    return './paths/**/*.js';
   }
 }

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -23,8 +23,8 @@ exports.config = {
         ignoreHTTPSErrors: true,
         args: [
           '--no-sandbox',
-          `--proxy-server=${process.env.E2E_PROXY_SERVER}`,
-          `--proxy-bypass-list=${process.env.E2E_PROXY_BYPASS}`
+          `--proxy-server=${process.env.E2E_PROXY_SERVER || ''}`,
+          `--proxy-bypass-list=${process.env.E2E_PROXY_BYPASS || ''}`
         ]
       }
     },
@@ -79,6 +79,6 @@ function getTests() {
   if (CONF.preview_env === 'true') {
     return './paths/**/basicDivorce.js';
   } else {
-    return './paths/**/*.js';
+    return './paths/**/logout.js';
   }
 }

--- a/test/end-to-end/helpers/idamHelper.js
+++ b/test/end-to-end/helpers/idamHelper.js
@@ -27,7 +27,7 @@ class IdamHelper extends Helper {
       idamConfigHelper.setTestEmail(testEmail);
       idamConfigHelper.setTestPassword(testPassword);
 
-      return idamExpressTestHarness.createUser(args)
+      return idamExpressTestHarness.createUser(args, process.env.E2E_PROXY_SERVER)
         .then(() => {
           logger.info('Created IDAM test user: ' + testEmail);
           return;
@@ -40,7 +40,7 @@ class IdamHelper extends Helper {
 
   _after() {
     if (CONF.features.idam) {
-      return idamExpressTestHarness.removeUser(args)
+      return idamExpressTestHarness.removeUser(args, process.env.E2E_PROXY_SERVER)
         .then(() => {
           logger.info('Removed IDAM test user: ' + args.testEmail);
           return;

--- a/test/end-to-end/helpers/idamHelper.js
+++ b/test/end-to-end/helpers/idamHelper.js
@@ -27,7 +27,7 @@ class IdamHelper extends Helper {
       idamConfigHelper.setTestEmail(testEmail);
       idamConfigHelper.setTestPassword(testPassword);
 
-      return idamExpressTestHarness.createUser(args, process.env.E2E_PROXY_SERVER)
+      return idamExpressTestHarness.createUser(args, process.env.E2E_IDAM_PROXY)
         .then(() => {
           logger.info('Created IDAM test user: ' + testEmail);
           return;
@@ -40,7 +40,7 @@ class IdamHelper extends Helper {
 
   _after() {
     if (CONF.features.idam) {
-      return idamExpressTestHarness.removeUser(args, process.env.E2E_PROXY_SERVER)
+      return idamExpressTestHarness.removeUser(args, process.env.E2E_IDAM_PROXY)
         .then(() => {
           logger.info('Removed IDAM test user: ' + args.testEmail);
           return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,13 +100,14 @@
     request-promise-native "^1.0.5"
     uuid "^3.1.0"
 
-"@hmcts/div-idam-test-harness@https://github.com/hmcts/div-idam-test-harness#1.0.12":
-  version "1.0.12"
-  resolved "https://github.com/hmcts/div-idam-test-harness#f8fd469199db63b42a59055e0c2b885dc5e49b5d"
+"@hmcts/div-idam-test-harness@https://github.com/hmcts/div-idam-test-harness#1.1.0":
+  version "1.1.0"
+  resolved "https://github.com/hmcts/div-idam-test-harness#fea4f5260aae0eafb609f33fb6871725a6f862b8"
   dependencies:
     "@hmcts/div-idam-express-middleware" "https://github.com/hmcts/div-idam-express-middleware#3.0.4"
     request "^2.81.0"
     request-promise-native "^1.0.4"
+    socks5-https-client "^1.0.3"
 
 "@hmcts/div-pay-client@https://github.com/hmcts/div-pay-client#6.0.0":
   version "6.0.0"
@@ -4437,6 +4438,18 @@ ioredis@^2.4.0:
     redis-commands "^1.2.0"
     redis-parser "^1.3.0"
 
+ip-address@~5.8.0:
+  version "5.8.9"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-5.8.9.tgz#6379277c23fc5adb20511e4d23ec2c1bde105dfd"
+  dependencies:
+    jsbn "1.1.0"
+    lodash.find "^4.6.0"
+    lodash.max "^4.0.1"
+    lodash.merge "^4.6.0"
+    lodash.padstart "^4.6.1"
+    lodash.repeat "^4.1.0"
+    sprintf-js "1.1.0"
+
 ip@^1.1.2, ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -4837,6 +4850,10 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -5158,6 +5175,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.find@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -5202,6 +5223,10 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.max@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.max/-/lodash.max-4.0.1.tgz#8735566c618b35a9f760520b487ae79658af136a"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -5218,9 +5243,17 @@ lodash.once@^4.0.0, lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
+lodash.padstart@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
+
 lodash.reduce@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
+lodash.repeat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.1.0.tgz#fc7de8131d8c8ac07e4b49f74ffe829d1f2bec44"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -7963,6 +7996,18 @@ socks-proxy-agent@^3.0.0:
     agent-base "^4.1.0"
     socks "^1.1.10"
 
+socks5-client@~1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/socks5-client/-/socks5-client-1.2.6.tgz#05b7d695bcdce56d2cbcde2c8d731c20cf87a253"
+  dependencies:
+    ip-address "~5.8.0"
+
+socks5-https-client@^1.0.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/socks5-https-client/-/socks5-https-client-1.2.1.tgz#c8d4a000e39cdc1651d90245af04a735d75d8b09"
+  dependencies:
+    socks5-client "~1.2.3"
+
 socks@1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/socks/-/socks-1.1.9.tgz#628d7e4d04912435445ac0b6e459376cb3e6d691"
@@ -8092,6 +8137,10 @@ split@0.3:
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
   dependencies:
     through "2"
+
+sprintf-js@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.0.tgz#cffcaf702daf65ea39bb4e0fa2b299cec1a1be46"
 
 sprintf-js@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Updated idamExpressTestHarness to latest 1.1.0, and related change in idamHelper.js

# Description

Updated idamExpressTestHarness to latest 1.1.0, and made a necessary change in idamHelper.js to pass the `E2E_PROXY_SERVER` value through for benefit of running locally against Preview. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally pointing to a preview instance to verify that IDAM test user can still be generated.


**Test Configuration**:

* Hardware: Mac
* O/S and version: OSX
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
