### PR TITLE
E2E test improvement for save & resume

### DIFF
--- a/test/end-to-end/paths/save-resume.js
+++ b/test/end-to-end/paths/save-resume.js
@@ -63,11 +63,14 @@ Scenario('Delete application from draft petition store', function (I) {
   }
 
   I.startApplication();
-
   I.checkMyAnswersRemoveApplication();
   I.confirmRemoveApplication();
-
   I.seeCurrentUrlEquals('/exit/removed-saved-application');
+
+  const ignoreIdam = true;
+  I.amOnLoadedPage('/index');
+  I.startApplication(ignoreIdam);
+  I.seeCurrentUrlEquals('/screening-questions/has-marriage-broken');
 });
 
 Scenario('Decline to delete application from draft petition store', function (I) {


### PR DESCRIPTION
# Description

This change improves the thoroughness of the `save-resume.js` e2e test, because without verifying that the journey starts from the beginning again after deleting a draft, the test is working on assumptions that might not be true.

Fixes # the test, innit

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally against AAT.


**Test Configuration**:

* Hardware: mac
* O/S and version: OSX
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
