### PR TITLE
Add missing addressBaseUK fields

### DIFF
--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -291,10 +291,10 @@ module.exports = class CheckYourAnswers extends ValidationStep {
     req.session = req.session || {};
 
     // add all missing addressBaseUK fields
-    forEach(req.session, oneElement => {
-      if (oneElement && typeof oneElement === 'object' && oneElement.selectAddressIndex >= 0 && oneElement.addresses && oneElement.addresses.length > 0 && !oneElement.addressBaseUK) {
-        oneElement.addressBaseUK = addressHelpers
-          .buildAddressBaseUk(oneElement.addresses[oneElement
+    forEach(req.session, element => {
+      if (element && typeof element === 'object' && element.selectAddressIndex >= 0 && element.addresses && element.addresses.length > 0 && !element.addressBaseUK) {
+        element.addressBaseUK = addressHelpers
+          .buildAddressBaseUk(element.addresses[element
             .selectAddressIndex]);
       }
     }

--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -292,7 +292,7 @@ module.exports = class CheckYourAnswers extends ValidationStep {
 
     // add all missing addressBaseUK fields
     forEach(req.session, oneElement => {
-      if (oneElement && typeof oneElement === 'object' && oneElement.selectAddressIndex && oneElement.addresses && oneElement.addresses.length > 0 && !oneElement.addressBaseUK) {
+      if (oneElement && typeof oneElement === 'object' && oneElement.selectAddressIndex >= 0 && oneElement.addresses && oneElement.addresses.length > 0 && !oneElement.addressBaseUK) {
         oneElement.addressBaseUK = addressHelpers
           .buildAddressBaseUk(oneElement.addresses[oneElement
             .selectAddressIndex]);

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -909,4 +909,95 @@ describe(modulePath, () => {
       });
     });
   });
+
+  describe('#update AddressBaseUK', () => {
+    let submit = {};
+    let postBody = {};
+
+    beforeEach(done => {
+      submit = sinon.stub().resolves({
+        error: null,
+        status: 'success',
+        caseId: '1234567890'
+      });
+      sinon.stub(submission, 'setup').returns({ submit });
+      sinon.stub(ga, 'trackEvent');
+
+      postBody = {
+        submit: true,
+        confirmPrayer: 'Yes'
+      };
+
+      session = {
+        question1: 'Yes',
+        confirmPrayer: 'Yes',
+        submit: true,
+        cookie: {},
+        expires: Date.now(),
+        petitionerHomeAddress: {
+          addressType: 'postcode',
+          selectAddressIndex: 0,
+          addresses: [
+            {
+              uprn: '100021861927',
+              organisation_name: '',
+              department_name: '',
+              po_box_number: '',
+              building_name: '',
+              sub_building_name: '',
+              building_number: 80,
+              thoroughfare_name: 'LANDOR ROAD',
+              dependent_thoroughfare_name: '',
+              dependent_locality: '',
+              double_dependent_locality: '',
+              post_town: 'LONDON',
+              postcode: 'SW9 9PE',
+              postcode_type: 'S',
+              formatted_address: '80 Landor Road\nLondon\nSW9 9PE'
+            }
+          ],
+          validPostcode: true,
+          postcodeError: false,
+          url: '/petitioner-respondent/address',
+          formattedAddress: {
+            whereabouts: ['80 Landor Road', 'London', 'SW9 9PE'],
+            postcode: 'SW9 9PE'
+          }
+        }
+      };
+      withSession(done, agent, session);
+    });
+
+    afterEach(() => {
+      ga.trackEvent.restore();
+      submission.setup.restore();
+    });
+
+    it('Missing addressBaseUK field is added if an address has been selected', done => {
+      const expectAddressBaseUK = {
+        addressLine1: '80 LANDOR ROAD',
+        addressLine2: '',
+        addressLine3: '',
+        postCode: 'SW9 9PE',
+        postTown: 'LONDON',
+        county: '',
+        country: 'UK'
+      };
+
+      const testSession = () => {
+        getSession(agent)
+          .then(sess => {
+            expect(sess.petitionerHomeAddress.addressBaseUK)
+              .to.eql(expectAddressBaseUK);
+          })
+          .then(done, done);
+      };
+
+      testCustom(testSession, agent, underTest, [], response => {
+        expect(response.res.headers.location)
+          .to.equal(s.steps.ApplicationSubmitted.url);
+      },
+      'post', true, postBody);
+    });
+  });
 });


### PR DESCRIPTION
# Description

Check that all the addresses having an uk address selected has also a populated addressBaseUK field. Populate this field if it's missing.
This could happen only with some old draft stored before 26 of june 2018


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Use the PR 232 to create a submission without addressBaseUk field. The PR 232 will not create the addressBaseUK field the first time an address is selected for the post code E2 0DP.
- After have selected an address, Save and close. Login again and use Swagger to check the session has no addressBaseUK field for the address in E2 0DP
- Log in PR 231 this time and add all missing fields, just before submission check the address field addressBaseUk is still missing. Click on submission and pay later. Login again, click on continue, check in swagger, the addressBaseUK fields are not missing.

Useful urls for this testing:
https://pr-232-div-pfe-preview.service.core-compute-preview.internal/
http://div-cps-aat.service.core-compute-aat.internal/swagger-ui.html#!/drafts-controller/retrieveDraftUsingGET
https://pr-231-div-pfe-preview.service.core-compute-preview.interna




**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules