### PR TITLE
Urgent content change to confidential details screen

### DIFF
--- a/app/steps/petitioner/confidential/content.json
+++ b/app/steps/petitioner/confidential/content.json
@@ -4,9 +4,10 @@
         "en": {
             "translation": {
                 "content": {
-                    "question": "Do you need your contact details kept private from your {{ divorceWho }}?",
-                    "divorcePetitionCopy": "A copy of your divorce petition will be sent to your {{ divorceWho }}.",
-                    "court": "The court won't include your address, email or phone number if you want them to be kept confidential.",
+                    "question": "Do you need your address and contact details kept private?",
+                    "divorcePetitionCopy": "A copy of your divorce application will be sent to your {{ divorceWho }}.",
+                    "court": "If you don’t want them to see your address, email or phone number you should ask the court to keep your details private.",
+                    "sameProperty": "You can’t keep your details private if you live in the same property as your {{ divorceWho }}.",
                     "share": "I don't need my contact details kept private",
                     "keep": "Keep my contact details private"
                 },

--- a/app/steps/petitioner/confidential/template.html
+++ b/app/steps/petitioner/confidential/template.html
@@ -13,6 +13,13 @@
 {{ content.court | safe }}
 </p>
 
+<div class="panel panel-border-wide">
+    <p class="text">
+        {{ content.sameProperty | safe }}
+    </p>
+
+</div>
+
 <div id="petitionerContactDetailsConfidential" class="form-group {{ 'form-group-error' if fields.petitionerContactDetailsConfidential.error }}">
     <fieldset>
         <legend class="visually-hidden">{{ content.question }}</legend>


### PR DESCRIPTION
Content change to stop users who live with their spouse from asking to keep their contact details private.