### PR TITLE
Fix bug where confirmPrayer was not being added to the session

### DIFF
--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -85,6 +85,24 @@ module.exports = class CheckYourAnswers extends ValidationStep {
     ];
   }
 
+  parseRequest(req) {
+    const ctx = super.parseRequest(req);
+
+    // if confirmPrayer has no value, set it to false
+    ctx.confirmPrayer = ctx.confirmPrayer || false;
+
+    ctx.requestMethod = req.method.toLowerCase();
+
+    const isPost = ctx.requestMethod === 'post';
+
+    // always set confirmPrayer to false on entering the page
+    if (!isPost) {
+      ctx.confirmPrayer = false;
+    }
+
+    return ctx;
+  }
+
   getStepCtx(step, session = {}) {
     let ctx = {};
 

--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -41,6 +41,8 @@ module.exports = class CheckYourAnswers extends ValidationStep {
     const [isValid] = this.validate(ctx, session);
 
     if (isValid) {
+      // apply ctx to session (this adds confirmPrayer to session before submission)
+      req.session = this.applyCtxToSession(ctx, session);
       // if application is valid submit it
       return this.submitApplication(req, res);
     }
@@ -49,8 +51,6 @@ module.exports = class CheckYourAnswers extends ValidationStep {
   }
 
   * interceptor(ctx, session) {
-    //  confirmPrayer and requestMethod are set by parseRequest prior to this call
-    // const requestMethod = ctx.requestMethod;
     const confirmPrayer = ctx.confirmPrayer;
 
     //  set the ctx to the current session then update with the current ctx
@@ -83,24 +83,6 @@ module.exports = class CheckYourAnswers extends ValidationStep {
       'about-divorce',
       'pay'
     ];
-  }
-
-  parseRequest(req) {
-    const ctx = super.parseRequest(req);
-
-    // if confirmPrayer has no value, set it to false
-    ctx.confirmPrayer = ctx.confirmPrayer || false;
-
-    ctx.requestMethod = req.method.toLowerCase();
-
-    const isPost = ctx.requestMethod === 'post';
-
-    // always set confirmPrayer to false on entering the page
-    if (!isPost) {
-      ctx.confirmPrayer = false;
-    }
-
-    return ctx;
   }
 
   getStepCtx(step, session = {}) {

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -415,7 +415,6 @@ describe(modulePath, () => {
         generateFields: sinon.stub().returns(fields),
         mapErrorsToFields: sinon.stub().returns(fields),
         checkYourAnswersTemplate: `${__dirname}/../../views/common/components/defaultCheckYouAnswersTemplate.html`,
-        parseRequest: sinon.stub().returns(ctx),
         section: 'test',
         url: '/test',
         template: 'template',
@@ -674,47 +673,67 @@ describe(modulePath, () => {
         sendStatus: sinon.stub()
       };
 
-      sinon.stub(underTest, 'parseCtx').resolves();
       sinon.stub(underTest, 'validate').returns([true]);
       sinon.stub(underTest, 'submitApplication');
     });
 
     afterEach(() => {
       underTest.submitApplication.restore();
-      underTest.parseCtx.restore();
       underTest.validate.restore();
     });
 
-    it('does not submit application if submit button not clicked', done => {
-      co(function* generator() {
-        yield underTest.postRequest(req, res);
-        expect(underTest.parseCtx.calledOnce).to.equal(true);
-        expect(underTest.validate.calledOnce).to.equal(true);
-        expect(underTest.submitApplication.called).to.equal(false);
-        done();
+    context('submission test', () => {
+      beforeEach(() => {
+        sinon.stub(underTest, 'parseCtx').resolves();
+      });
+
+      afterEach(() => {
+        underTest.parseCtx.restore();
+      });
+
+      it('does not submit application if submit button not clicked', done => {
+        co(function* generator() {
+          yield underTest.postRequest(req, res);
+          expect(underTest.parseCtx.calledOnce).to.equal(true);
+          expect(underTest.validate.calledOnce).to.equal(true);
+          expect(underTest.submitApplication.called).to.equal(false);
+          done();
+        });
+      });
+
+      it('runs submit application if submission is valid', done => {
+        co(function* generator() {
+          req.body.submit = true;
+          yield underTest.postRequest(req, res);
+          expect(underTest.parseCtx.calledOnce).to.equal(true);
+          expect(underTest.validate.calledOnce).to.equal(true);
+          expect(underTest.submitApplication.calledOnce).to.equal(true);
+          done();
+        });
+      });
+
+      it('does not submit application if invalid', done => {
+        co(function* generator() {
+          req.body.submit = true;
+          underTest.validate.returns([false]);
+          yield underTest.postRequest(req, res);
+          expect(underTest.parseCtx.calledTwice).to.equal(true);
+          expect(underTest.validate.calledTwice).to.equal(true);
+          expect(underTest.submitApplication.called).to.equal(false);
+          done();
+        });
       });
     });
 
-    it('runs submit application if submission is valid', done => {
-      co(function* generator() {
-        req.body.submit = true;
-        yield underTest.postRequest(req, res);
-        expect(underTest.parseCtx.calledOnce).to.equal(true);
-        expect(underTest.validate.calledOnce).to.equal(true);
-        expect(underTest.submitApplication.calledOnce).to.equal(true);
-        done();
-      });
-    });
-
-    it('does not submit application if invalid', done => {
-      co(function* generator() {
-        req.body.submit = true;
-        underTest.validate.returns([false]);
-        yield underTest.postRequest(req, res);
-        expect(underTest.parseCtx.calledTwice).to.equal(true);
-        expect(underTest.validate.calledTwice).to.equal(true);
-        expect(underTest.submitApplication.called).to.equal(false);
-        done();
+    context('session test', () => {
+      it('sets confirmPrayer to Yes when set in the ctx', done => {
+        co(function* generator() {
+          req.body.submit = true;
+          req.body.confirmPrayer = 'Yes';
+          yield underTest.postRequest(req, res);
+          expect(req.session.confirmPrayer).to.equal('Yes');
+          done();
+        });
       });
     });
   });

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -415,6 +415,7 @@ describe(modulePath, () => {
         generateFields: sinon.stub().returns(fields),
         mapErrorsToFields: sinon.stub().returns(fields),
         checkYourAnswersTemplate: `${__dirname}/../../views/common/components/defaultCheckYouAnswersTemplate.html`,
+        parseRequest: sinon.stub().returns(ctx),
         section: 'test',
         url: '/test',
         template: 'template',


### PR DESCRIPTION
[DIV-2979](https://tools.hmcts.net/jira/browse/DIV-2979)

D8StatementOfTruth which is mapped from DivorceSession.confirmPrayer was not being set in CCD. The reason was a change which no longer did submission after the CYA but as part of it, meaning the confirmPrayer variable was never added to the session before submission to CCD, but only after it, meaning it wasn't saved.
This would mean D8StatementOfTruth is null in CCD for these scenarios.
The second scenario where D8StatementOfTruth is set to 'No' would occur if the user did a Save and Close on CYA and then resumed and submitted.

The change basically adds in adding the current ctx to the session before the submission occurs.