### PR TITLE
stability fix for manual postcode e2e test

### DIFF
--- a/test/end-to-end/pages/address/manual.js
+++ b/test/end-to-end/pages/address/manual.js
@@ -3,7 +3,8 @@ function enterAddressManually(stepUrl) {
   const I = this;
 
   I.seeCurrentUrlEquals(stepUrl);
-  I.click('#enter-manual');
+  I.navByClick('#enter-manual');
+  I.waitForVisible('#addressManual');
   I.fillField('addressManual', 'some address entered manually');
   I.navByClick('Continue');
 }


### PR DESCRIPTION
# Description

This is a fix for the manual postcode e2e tests, where puppeteer `click()` was not waiting sufficiently before trying to fill the field. Now it uses `nacByClick()` to correctly wait for all Network traffic to finish before trying to continue.

Fixes # master

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test only change

# How Has This Been Tested?

This has been tested locally against AAT and proves the fix works, and will run on Preview.


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
