### PR TITLE
[PREVIEW] Use waitInUrl instead of seeCurrentUrlEquals

### DIFF
--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -78,7 +78,7 @@ function configureChunks() {
 function getTests() {
   console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
   if (CONF.preview_env === 'true') {
-    return './paths/**/pay/*.js';
+    return './paths/**/payment.js';
   } else {
     return './paths/**/*.js';
   }

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -78,7 +78,7 @@ function configureChunks() {
 function getTests() {
   console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
   if (CONF.preview_env === 'true') {
-    return './paths/**/basicDivorce.js';
+    return './paths/**/pay/*.js';
   } else {
     return './paths/**/*.js';
   }

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -78,7 +78,7 @@ function configureChunks() {
 function getTests() {
   console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
   if (CONF.preview_env === 'true') {
-    return './paths/**/payment.js';
+    return './paths/**/basicDivorce.js';
   } else {
     return './paths/**/*.js';
   }

--- a/test/end-to-end/pages/pay/by-card-online-on-govpay.js
+++ b/test/end-to-end/pages/pay/by-card-online-on-govpay.js
@@ -55,7 +55,7 @@ function cancelOnGovPay() {
 function onGovPay(I) {
   I.wait(3);
   I.waitForText('Enter card details', 20);
-  I.seeInCurrentUrl('www.payments.service.gov.uk/card_details');
+  I.waitInUrl('www.payments.service.gov.uk/card_details');
   I.see('£550.00');
 }
 


### PR DESCRIPTION
Our existing seeCurrentUrlEquals which is a codecept method is being intercepted in the JSWait Helper class and waits for the DOM Element #content before proceeding.
Gov.UK Payment page recently changed the id of that element to #maincontent instead meaning our E2E tests no longer  find what we are expecting and the test times out and fails.
This PR changes the seeCurrentUrlEquals to a WaitInUrl (also codecept function) that does a similar thing to seeCurrentUrlEquals but with improved checking for page load logic, but more importantly does not check for a DOM element that isn't in our control.