### PR TITLE
DIV-2629: Removed gendered pronouns being used

### DIFF
--- a/app/steps/jurisdiction/interstitial/content.json
+++ b/app/steps/jurisdiction/interstitial/content.json
@@ -31,7 +31,7 @@
                         "helpText1": "If your life is mainly based in England or Wales then you're what is legally known as 'habitually resident'.",
                         "helpText2": "This may include working, owning property, having children in school, and your main family life taking place in England or Wales.",
                         "helpText3": "The examples above aren't a complete list of what makes up habitual residence, and just because some of them apply to you doesn’t mean you’re habitually resident. If you’re not sure, you should get legal advice.",
-                        "clarification": "You only need to do this if your {{ divorceWho }} may disagree that he/she is habitually resident."
+                        "clarification": "You only need to do this if your {{ divorceWho }} may disagree that they are habitually resident."
                     },
                     "D": {
                         "summary": "Your answers indicate that you can apply for a divorce in England and Wales because you are 'habitually resident' and have lived here for at least 12 months.",

--- a/app/steps/respondent/correspondence/send-to-solicitor/content.json
+++ b/app/steps/respondent/correspondence/send-to-solicitor/content.json
@@ -7,8 +7,8 @@
                 "content": {
                     "question": "Where should your {{ divorceWho }}'s divorce papers be sent?",
                     "correspondence": "To a different address",
-                    "solicitor-wife": "To her solicitor's address",
-                    "solicitor-husband": "To his solicitor's address"
+                    "solicitor-wife": "To their solicitor's address",
+                    "solicitor-husband": "To their solicitor's address"
                 },
 
                 "errors": {

--- a/app/steps/respondent/correspondence/use-home-address/content.json
+++ b/app/steps/respondent/correspondence/use-home-address/content.json
@@ -9,8 +9,8 @@
                     "correspondence": "If your {{ divorceWho }} has given you an address for the papers to be sent (known as a correspondence address) you must give that address to the court.",
                     "yes": "Yes, use this address",
                     "no": "No, send them to a different address",
-                    "solicitor-wife": "No, send them to her solicitor's address",
-                    "solicitor-husband": "No, send them to his solicitor's address"
+                    "solicitor-wife": "No, send them to their solicitor's address",
+                    "solicitor-husband": "No, send them to their solicitor's address"
                 },
 
                 "checkYourAnswersContent": {

--- a/app/steps/respondent/home/lives-at-last-address/content.json
+++ b/app/steps/respondent/home/lives-at-last-address/content.json
@@ -7,10 +7,10 @@
                 "content": {
                     "question": "Does your {{ divorceWho }} still live at this address?",
                     "yes": "Yes",
-                    "no-husband": "No, he lives at another address",
-                    "unknown-husband": "No, and I don't know where he lives",
-                    "no-wife": "No, she lives at another address",
-                    "unknown-wife": "No, and I don't know where she lives"
+                    "no-husband": "No, they live at another address",
+                    "unknown-husband": "No, and I don't know where they lives",
+                    "no-wife": "No, they live at another address",
+                    "unknown-wife": "No, and I don't know where they lives"
                 },
 
                 "errors": {


### PR DESCRIPTION
Fixes DIV-2629
Simple change to text of questions that removes 'him', 'his', 'her', 'he', 'she' etc and replaces with contextually relevant gender agnostic terminology i.e. 'they/their/them'