### PR TITLE
Fix logout for sidam

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -105,6 +105,7 @@ module "frontend" {
     IDAM_LOGIN_URL                     = "${var.idam_authentication_web_url}${var.idam_authentication_login_endpoint}"
     IDAM_AUTHENTICATION_HEALHCHECK_URL = "${var.idam_authentication_web_url}${var.health_endpoint}"
     IDAM_SECRET                        = "${data.azurerm_key_vault_secret.idam_secret.value}"
+    IDAM_CLIENT_ID                     = "${var.idam_client_id}"
 
     // Service Auth
     SERVICE_AUTH_PROVIDER_URL             = "${local.service_auth_provider_url}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -135,6 +135,10 @@ variable "idam_api_url" {
   type = "string"
 }
 
+variable "idam_client_id" {
+  default = "divorce"
+}
+
 variable "service_auth_provider_url" {
   default = ""
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint"
   ],
   "dependencies": {
-    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#6.1.0",
+    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#6.2.0",
     "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#6.0.0",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#3.0.0",
     "@hmcts/nodejs-healthcheck": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint"
   ],
   "dependencies": {
-    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#6.0.0",
+    "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#6.1.0",
     "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#6.0.0",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#3.0.0",
     "@hmcts/nodejs-healthcheck": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,9 +91,9 @@
     request-promise-native "^1.0.5"
     uuid "^3.1.0"
 
-"@hmcts/div-idam-express-middleware@https://github.com/hmcts/div-idam-express-middleware#6.0.0":
-  version "6.0.0"
-  resolved "https://github.com/hmcts/div-idam-express-middleware#3b2466873627729a157b5c831217ff9610ed969d"
+"@hmcts/div-idam-express-middleware@https://github.com/hmcts/div-idam-express-middleware#6.2.0":
+  version "6.2.0"
+  resolved "https://github.com/hmcts/div-idam-express-middleware#1649ded471849698550c7780269ac1a4ffe9803d"
   dependencies:
     "@hmcts/nodejs-logging" "^2.2.0"
     request "^2.83.0"


### PR DESCRIPTION
*** NOTE: REQUIRED PRIOR TO SIDAM RELEASE ***

SIDAM requires authentication for logout.

Frontend was missing the client_id and required a change to be made in idam-express-middleware. This PR adds in the client_id to be passed from the infrastructure (was using the default.yml from config) and uses the new idam-express-middleware version.