### PR TITLE
Parse the boolean for the flag so even strings resolve correctly

### DIFF
--- a/app/core/utils/parseBool.js
+++ b/app/core/utils/parseBool.js
@@ -1,3 +1,3 @@
 module.exports = (bool = '') => {
-  return typeof bool === 'string' ? bool.toLowerCase() === 'true' : bool === true;
+  return String(bool) === 'true';
 };

--- a/app/core/utils/parseBool.js
+++ b/app/core/utils/parseBool.js
@@ -1,0 +1,3 @@
+module.exports = (bool = '') => {
+  return typeof bool === 'string' ? bool.toLowerCase() === 'true' : bool === true;
+};

--- a/app/core/utils/parseBool.test.js
+++ b/app/core/utils/parseBool.test.js
@@ -1,0 +1,26 @@
+const modulePath = 'app/core/utils/parseBool';
+const parseBool = require(modulePath);
+
+const { expect } = require('test/util/chai');
+
+describe(modulePath, () => {
+  it('should return true when given boolean true', () => {
+    expect(true, parseBool(true));
+  });
+
+  it('should return true when given string true', () => {
+    expect(true, parseBool('true'));
+  });
+
+  it('should return false when given boolean false', () => {
+    expect(false, parseBool(false));
+  });
+
+  it('should return false when given string false', () => {
+    expect(false, parseBool('false'));
+  });
+
+  it('should return false when given a random string', () => {
+    expect(false, parseBool('random string'));
+  });
+});

--- a/app/middleware/submissionMiddleware.js
+++ b/app/middleware/submissionMiddleware.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const parseBool = require('app/core/utils/parseBool');
 
 const APPLICATION_SUBMITTED_PATH = '/application-submitted';
 const APPLICATION_AWAITING_RESPONSE_PATH = '/application-submitted-awaiting-response';
@@ -21,7 +22,7 @@ const hasSubmitted = function(req, res, next) {
   }
 
   // when a new case has just been submitted for the session
-  if (config.features.redirectToApplicationSubmitted && session.caseId) {
+  if (parseBool(config.features.redirectToApplicationSubmitted) && session.caseId) { // eslint-line-disable
     return res.redirect(APPLICATION_SUBMITTED_PATH);
   }
 

--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -1,4 +1,5 @@
 const CONF = require('config');
+const parseBool = require('app/core/utils/parseBool');
 
 Feature('Invalid Paths Handling').retry(3);
 
@@ -25,7 +26,7 @@ Scenario('Redirects to cookie error page if start application with no cookies', 
 
 Scenario('Redirects to application submitted page if case already submitted with feature flag', (I) => {
 
-  if (CONF.features.redirectToApplicationSubmitted) {
+  if (parseBool(CONF.features.redirectToApplicationSubmitted)) {
     I.startApplicationWithAnExistingSession();
     I.amOnLoadedPage('/pay/help/need-help');
     I.selectHelpWithFees(false);


### PR DESCRIPTION
When infrastructure variables are taken in by config, they are converted to String. Locally this is the case as well when trying to pass in an env variable such as FEATURE_REDIRECT_TO_APPLICATION_SUBMITTED=false, the code treats that as boolean true strangely. Passing is as false directly to the default.yml does not have this issue.

This code change parses the passed in parameter and if string, checks its equivalent to a string 'true' or if not, to the Boolean true.