### PR TITLE
[PREVIEW] - Update content on adultery SOC

### DIFF
--- a/app/steps/grounds-for-divorce/adultery/details/content.json
+++ b/app/steps/grounds-for-divorce/adultery/details/content.json
@@ -7,6 +7,7 @@
                     "question": "Your account of the adultery",
                     "description": "Provide the following information about the adultery. If you don't know any of this information, say that you don't know and explain why.",
                     "remember": "Your {{ divorceWho }}  will be sent a copy of your divorce application, so you may want to avoid writing anything that will cause conflict between you. You can discuss your statement with your {{ divorceWho }} if you want to.",
+                    "rejected": "Your application will be rejected if you don’t provide enough information to convince the court that your {{ divorceWho }} committed adultery.",
                     "whatDoYouKnow": "What do you know about the adultery?",
                     "whatElseDoYouKnow": "What else do you know about the adultery?",
                     "whereDidAdulteryHappen": "Where did the adultery happen?",

--- a/app/steps/grounds-for-divorce/adultery/details/template.html
+++ b/app/steps/grounds-for-divorce/adultery/details/template.html
@@ -12,6 +12,8 @@
         <p class="text">{{ content.remember | safe }}</p>
     </div>
 
+    <p class="text">{{ content.rejected | safe }}</p>
+
     {% if (fields.reasonForDivorceAdulteryKnowWhen.value === "Yes") %}
         {{ textArea(
             name='reasonForDivorceAdulteryWhenDetails',


### PR DESCRIPTION
[DIV-3669 - Add content warning users not to leave SOC blank in adultery cases](https://tools.hmcts.net/jira/browse/DIV-3669)

RDCs have asked to add a line that warns people about not submitting enough information in their adultery SOC.