### PR TITLE
Fix failing e2e test

### DIFF
--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -69,7 +69,7 @@ function configureChunks() {
   if (CONF.preview_env === 'true') {
     return 2;
   } else {
-    return 4;
+    return 5;
   }
 }
 

--- a/test/end-to-end/pages/pay/by-card-online-on-govpay.js
+++ b/test/end-to-end/pages/pay/by-card-online-on-govpay.js
@@ -38,7 +38,7 @@ function payOnGovPayFailure() {
   I.fillField('email', 'simulate-delivered+divorce@notifications.service.gov.uk');
   I.navByClick('Continue');
   I.waitForText('Your payment has been declined');
-  I.navByClick('Go back to try the payment again');
+  I.navByClick('Continue');
 }
 
 function cancelOnGovPay() {


### PR DESCRIPTION
Reusing 5 threads since it wasn't a concurrency issue.

The test was failing because the Button Text on Gov Pay site was changed from 'Go Back and Try The Payment Again' to 'Continue'.
For now I've done the quick change. We can discuss how to handle third party service content later.