### PR TITLE
DIV-3766 Apply fix to remove healthcheck for IDAM requiring proxy

### DIFF
--- a/app/services/healthcheck.js
+++ b/app/services/healthcheck.js
@@ -45,9 +45,6 @@ router.get('/health', healthcheck.configure({
           });
         });
     }),
-    'idam-authentication': healthcheck.web(config.services.idamAuthentication.health,
-      healthOptions('Health check failed on idam-authentication:')
-    ),
     'idam-app': healthcheck.web(config.services.idamApp.health,
       healthOptions('Health check failed on idam-app:')
     ),


### PR DESCRIPTION
# Description

Recently, DevOps have introduced a proxy requirement for this endpoint (ticket RDO-3077)

The healthcheck module currently doesn't support a proxy, so we're removing this temporarily.

Fixes #DIV-3766

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
