### PR TITLE
DIV-3830: Changed simulate email address with valid gmail for int tests

### DIFF
--- a/app/middleware/idamProtectMiddleware.test.js
+++ b/app/middleware/idamProtectMiddleware.test.js
@@ -18,7 +18,7 @@ describe(modulePath, () => {
     req = {};
     res = {};
     next = sinon.stub();
-    userDetails = { email: 'email@email.com' };
+    userDetails = { email: 'simulate-delivered@notifications.service.gov.uk' };
     const protectStub = sinon.stub().callsArgWith(two, userDetails);
     sinon.stub(idam, 'protect').returns(protectStub);
   });

--- a/app/middleware/setIdamDetailsToSessionMiddleware.test.js
+++ b/app/middleware/setIdamDetailsToSessionMiddleware.test.js
@@ -7,7 +7,7 @@ let req = {};
 let res = {};
 let next = {};
 const userDetails = {
-  email: 'email@email.com',
+  email: 'simulate-delivered@notifications.service.gov.uk',
   id: 'user.id'
 };
 const validSession = { expires: 1111 };

--- a/app/services/transformationServiceClient.test.js
+++ b/app/services/transformationServiceClient.test.js
@@ -86,12 +86,12 @@ describe(modulePath, () => {
         json: true
       });
     });
-    it('appends pertitioner email to uri if send email arguement is true', () => {
+    it('appends petitioner email to uri if send email argument is true', () => {
       // Arrange.
       const userToken = 'user.token';
       const body = {
         foo: 'bar',
-        petitionerEmail: 'test@test.com'
+        petitionerEmail: 'simulate-delivered@notifications.service.gov.uk'
       };
       const petitionerEmail = encodeURIComponent(body.petitionerEmail);
       // Act.

--- a/app/steps/pay/card-payment-status/index.test.js
+++ b/app/steps/pay/card-payment-status/index.test.js
@@ -21,7 +21,7 @@ let agent = {};
 let underTest = {};
 const userDetails = {
   id: 1,
-  email: 'email@email.com'
+  email: 'simulate-delivered@notifications.service.gov.uk'
 };
 const idamUserDetailsMiddlewareMock = (req, res, next) => {
   req.idam = { userDetails };

--- a/app/steps/pay/pay-online-only/index.test.js
+++ b/app/steps/pay/pay-online-only/index.test.js
@@ -31,7 +31,7 @@ const amount = parseInt(
 );
 const userDetails = {
   id: 1,
-  email: 'email@email.com'
+  email: 'simulate-delivered@notifications.service.gov.uk'
 };
 const idamUserDetailsMiddlewareMock = (req, res, next) => {
   req.idam = { userDetails };

--- a/app/steps/petitioner/contact-details/index.test.js
+++ b/app/steps/petitioner/contact-details/index.test.js
@@ -122,7 +122,7 @@ describe(modulePath, () => {
   describe('Check Your Answers', () => {
     it('renders the cya template', done => {
       const dataPhoneNumber = { petitionerPhoneNumber: '0123456789' };
-      const session = { petitionerEmail: 'test@test.com' };
+      const session = { petitionerEmail: 'simulate-delivered@notifications.service.gov.uk' };
       testCYATemplate(done, underTest, dataPhoneNumber, session);
     });
 

--- a/test/end-to-end/helpers/idamHelper.js
+++ b/test/end-to-end/helpers/idamHelper.js
@@ -14,11 +14,12 @@ class IdamHelper extends Helper {
 
   _before() {
     if (CONF.features.idam) {
-      const emailName = 'simulate-delivered-' + randomstring.generate({
+      const randomString = randomstring.generate({
         length: 16,
         charset: 'numeric'
       });
-      const testEmail = emailName + '@notifications.service.gov.uk';
+      const emailName = `hmcts.divorce.reform+automatedtest-${randomString}`;
+      const testEmail = `${emailName}@gmail.com`;
       const testPassword = randomstring.generate(9);
 
       args.testEmail = testEmail;

--- a/test/end-to-end/helpers/idamHelper.js
+++ b/test/end-to-end/helpers/idamHelper.js
@@ -18,7 +18,7 @@ class IdamHelper extends Helper {
         length: 16,
         charset: 'numeric'
       });
-      const emailName = `hmcts.divorce.reform+automatedtest-${randomString}`;
+      const emailName = `hmcts.divorce.reform+pfe-automatedtest-${randomString}`;
       const testEmail = `${emailName}@gmail.com`;
       const testPassword = randomstring.generate(9);
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-3830

Replace ‘email@email.com’ from emails from integration tests as it is spamming notification service when we run integration tests. 
Created new HMCTS Divorce gmail account for testing with unique users