### PR TITLE
Fix azurerm provider number to 1.19.0

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  version = "1.19.0"
+}
+
 data "azurerm_key_vault" "div_key_vault" {
   name                = "${local.vaultName}"
   resource_group_name = "${local.vaultName}"


### PR DESCRIPTION

# Description
From devops:
There's a bug in the azurerm provider, pin your azurerm provider to version 1.19.0 to fix

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
