### PR TITLE
Brings the prod config court allocation ratios

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -25,11 +25,3 @@ decree_nisi_frontend_url = "https://www.decree-nisi.apply-divorce.service.gov.uk
 capacity = "2"
 
 feature_redirect_on_state = "false"
-
-court_service_centre_divorce_facts_ratio = {
-  "unreasonable-behaviour" = 0
-  "separation-2-years" = 0
-  "separation-5-years" = 0
-  "adultery" = 0
-  "desertion" = 0
-}


### PR DESCRIPTION
in line with AAT

The current settings are:

variable "court_eastmidlands_weight" {
  default = 0
}

variable "court_westmidlands_weight" {
  default = 0
}


variable "court_southwest_weight" {
  default = 0.5
}

variable "court_northwest_weight" {
  default = 0.5
}

variable "court_service_centre_weight" {
  default = 0.30
}

variable "court_service_centre_divorce_facts_ratio" {
  type = "map"
  default = {
    "unreasonable-behaviour" = 1
    "separation-2-years" = 0
    "separation-5-years" = 0
    "adultery" = 0
    "desertion" = 0
  }
}

variable "divorce_facts_ratio" {
  type = "map"

  default = {
    "unreasonable-behaviour" = 0.30
    "separation-2-years"     = 0.37
    "separation-5-years"     = 0.21
    "adultery"               = 0.11
    "desertion"              = 0.01
  }
}

I think the facts ratio takes priority, so setting 1 on CTSC gives all unreasonable-behaviour cases to CTSC (as long as the court weight is not 0)
Then the remaining ratios are not set for the 4 courts, so the weightings do not apply. In this case, the remaining cases excluding unreasonable-behaviour cases should go 50% to southWest and 50% to northWest.
0% to eastMidlands and 0% will go to westMidlands right now.