### PR TITLE
DIV-4005 apply empty saveAndClose block to ensure no button show

### DIFF
--- a/app/steps/screening-questions/has-marriage-cert/index.test.js
+++ b/app/steps/screening-questions/has-marriage-cert/index.test.js
@@ -1,10 +1,11 @@
 const request = require('supertest');
-const { testContent, testErrors, testRedirect } = require('test/util/assertions');
+const { testContent, testErrors, testRedirect, testNonExistence } = require('test/util/assertions');
 const server = require('app');
 const idamMock = require('test/mocks/idam');
 
 const modulePath = 'app/steps/screening-questions/has-marriage-cert';
 const content = require(`${modulePath}/content`);
+const commonContent = require('app/content/common');
 
 let s = {};
 let agent = {};
@@ -44,6 +45,11 @@ describe(modulePath, () => {
 
       testRedirect(done, agent, underTest, context,
         s.steps.ExitMarriageCertificate);
+    });
+
+    it('does not render save and close button', done => {
+      testNonExistence(done, agent, underTest,
+        commonContent.resources.en.translation.saveAndClose);
     });
   });
 });

--- a/app/steps/screening-questions/has-marriage-cert/template.html
+++ b/app/steps/screening-questions/has-marriage-cert/template.html
@@ -11,7 +11,7 @@
    <div class="panel panel-border-wide">
     <p class="text"> {{content.camera | safe }}</p>
     </div>
-    
+
     <p class="text"> {{content.certificateTranslation | safe }}</p>
 
     {{ yesNoRadioHeading(
@@ -24,3 +24,5 @@
     ) }}
 
 {% endblock %}
+
+{% block saveAndClose %}{% endblock %}

--- a/app/steps/screening-questions/has-respondent-address/index.test.js
+++ b/app/steps/screening-questions/has-respondent-address/index.test.js
@@ -1,11 +1,12 @@
 const request = require('supertest');
-const { testContent, testErrors, testRedirect } = require('test/util/assertions');
+const { testContent, testErrors, testRedirect, testNonExistence } = require('test/util/assertions');
 const server = require('app');
 const idamMock = require('test/mocks/idam');
 
 const modulePath = 'app/steps/screening-questions/has-respondent-address';
 
 const content = require(`${modulePath}/content`);
+const commonContent = require('app/content/common');
 
 let s = {};
 let agent = {};
@@ -46,6 +47,11 @@ describe(modulePath, () => {
 
       testRedirect(done, agent, underTest, context,
         s.steps.ExitRespondentAddress);
+    });
+
+    it('does not render save and close button', done => {
+      testNonExistence(done, agent, underTest,
+        commonContent.resources.en.translation.saveAndClose);
     });
   });
 });

--- a/app/steps/screening-questions/has-respondent-address/template.html
+++ b/app/steps/screening-questions/has-respondent-address/template.html
@@ -24,3 +24,5 @@
     ) }}
 
 {% endblock %}
+
+{% block saveAndClose %}{% endblock %}


### PR DESCRIPTION
# Description

Re-apply the saveAndClose block, as an empty block, so no Save And Close button gets rendered out. This draft store functionality is not intended for screening questions.

Fixes # DIV-4005

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual testing

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
