### PR TITLE
Add missing feature_release 510 to the env outputs

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -21,3 +21,7 @@ output "feature_redirect_to_application_submitted" {
 output "feature_respondent_consent" {
   value = "${var.feature_respondent_consent}"
 }
+
+output "feature_release_510" {
+  value = "${var.feature_release_510}"
+}


### PR DESCRIPTION
For E2E tests to pickup.

default.yml has the feature_release_510 flag as true, but the envs are set to false. This means the tests are picking up the default config. This adds to the output.tf the current env value so that is correctly passed to the test config.