### PR TITLE
Fixed getSeparationTimeTogetherPermitted text for more than 6 month s…

### DIFF
--- a/app/services/separationDates.js
+++ b/app/services/separationDates.js
@@ -62,32 +62,23 @@ const formattedMostRecentSepDate = session => {
 };
 
 const getSeparationTimeTogetherPermitted = session => {
-  const dateBeforeSepYears = getDateBeforeSepYears(session);
-  const timeTogether = moment(
-    dateBeforeSepYears.diff(
-      moment(getMostRecentSeparationDate(session)))
-  ).toObject();
-  if (timeTogether.years > constants.zeroYear || timeTogether.months >= constants.six) {
+  const timeTogetherMonths = getLivingTogetherMonths(session);
+  const timeTogetherWeeks = getLivingTogetherWeeks(session);
+  const timeTogetherDays = getLivingTogetherDays(session) % constants.seven;
+
+  if (timeTogetherMonths >= constants.six) {
     return '6 months';
   }
   let permittedSepTime = '';
-  if (timeTogether.months === 1) {
-    permittedSepTime = `${timeTogether.months} month`;
+  if (timeTogetherWeeks === 1) {
+    permittedSepTime = `${timeTogetherWeeks} week`;
+  } else if (timeTogetherWeeks > 1) {
+    permittedSepTime = `${timeTogetherWeeks} weeks`;
   }
-  if (timeTogether.months > 1) {
-    permittedSepTime = `${timeTogether.months} months`;
-  }
-  if (Math.trunc(timeTogether.date / constants.seven) === 1) {
-    permittedSepTime = `${`${permittedSepTime}, ${Math.trunc(timeTogether.date / constants.seven)}`} week`;
-  }
-  if (Math.trunc(timeTogether.date / constants.seven) > 1) {
-    permittedSepTime = `${`${permittedSepTime}, ${Math.trunc(timeTogether.date / constants.seven)}`} weeks`;
-  }
-  if (timeTogether.date % constants.seven === 1) {
-    permittedSepTime = `${`${permittedSepTime} and ${timeTogether.date % constants.seven}`} day`;
-  }
-  if (timeTogether.date % constants.seven > 1) {
-    permittedSepTime = `${`${permittedSepTime} and ${timeTogether.date % constants.seven}`} days`;
+  if (timeTogetherDays === 1) {
+    permittedSepTime = `${`${permittedSepTime} and ${timeTogetherDays}`} day`;
+  } else if (timeTogetherDays > 1) {
+    permittedSepTime = `${`${permittedSepTime} and ${timeTogetherDays}`} days`;
   }
   return permittedSepTime;
 };

--- a/app/services/separationDates.js
+++ b/app/services/separationDates.js
@@ -68,7 +68,7 @@ const getSeparationTimeTogetherPermitted = session => {
       moment(getMostRecentSeparationDate(session)))
   ).toObject();
   if (timeTogether.years > constants.zeroYear || timeTogether.months > constants.six) {
-    return getReferenceDate(session);
+    return '6 months';
   }
   let permittedSepTime = '';
   if (timeTogether.months === 1) {

--- a/app/services/separationDates.js
+++ b/app/services/separationDates.js
@@ -67,7 +67,7 @@ const getSeparationTimeTogetherPermitted = session => {
     dateBeforeSepYears.diff(
       moment(getMostRecentSeparationDate(session)))
   ).toObject();
-  if (timeTogether.years > constants.zeroYear || timeTogether.months > constants.six) {
+  if (timeTogether.years > constants.zeroYear || timeTogether.months >= constants.six) {
     return '6 months';
   }
   let permittedSepTime = '';

--- a/app/services/separationDates.js
+++ b/app/services/separationDates.js
@@ -75,10 +75,13 @@ const getSeparationTimeTogetherPermitted = session => {
   } else if (timeTogetherWeeks > 1) {
     permittedSepTime = `${timeTogetherWeeks} weeks`;
   }
+  if (timeTogetherWeeks > 0 && timeTogetherDays > 0) {
+    permittedSepTime = `${permittedSepTime} and `;
+  }
   if (timeTogetherDays === 1) {
-    permittedSepTime = `${`${permittedSepTime} and ${timeTogetherDays}`} day`;
+    permittedSepTime = `${`${permittedSepTime}${timeTogetherDays}`} day`;
   } else if (timeTogetherDays > 1) {
-    permittedSepTime = `${`${permittedSepTime} and ${timeTogetherDays}`} days`;
+    permittedSepTime = `${`${permittedSepTime}${timeTogetherDays}`} days`;
   }
   return permittedSepTime;
 };

--- a/app/services/separationDates.test.js
+++ b/app/services/separationDates.test.js
@@ -25,7 +25,20 @@ describe(modulePath, () => {
   });
 
   describe('getSeparationTimeTogetherPermitted', () => {
-    it('should return more than 6 months when time together permitted is greater than six', () => {
+    it('should return more than 6 months when time together permitted is greater than 1 year', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(15, constants.months);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('6 months').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return more than 6 months when time together permitted is greater than six months', () => {
       const separationDate = moment().startOf(constants.days)
         .subtract(5, constants.years)
         .subtract(9, constants.months);
@@ -38,10 +51,36 @@ describe(modulePath, () => {
       expect('6 months').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
     });
 
-    it('should return months, weeks and days when time together permitted is less than 6 months', () => {
+    it('should return more than 6 months when time together permitted is six months', () => {
       const separationDate = moment().startOf(constants.days)
         .subtract(5, constants.years)
-        .subtract(3, constants.months)
+        .subtract(6, constants.months);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('6 months').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return 25 weeks and a bit when time together permitted is slightly under six months', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(6, constants.months)
+        .add(1, constants.days);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('25 weeks and 6 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return weeks and days when time together permitted is less than 6 months', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
         .subtract(2, constants.weeks)
         .subtract(2, constants.days);
       session = {
@@ -50,13 +89,12 @@ describe(modulePath, () => {
         reasonForDivorceLivingApartDate: separationDate
       };
 
-      expect('3 months, 2 weeks and 3 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+      expect('2 weeks and 2 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
     });
 
     it('should return month, week and day when time together permitted is less than 6 months', () => {
       const separationDate = moment().startOf(constants.days)
         .subtract(5, constants.years)
-        .subtract(1, constants.months)
         .subtract(1, constants.weeks)
         .subtract(1, constants.days);
       session = {
@@ -65,7 +103,7 @@ describe(modulePath, () => {
         reasonForDivorceLivingApartDate: separationDate
       };
 
-      expect('1 month, 1 week and 1 day').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+      expect('1 week and 1 day').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
     });
   });
 });

--- a/app/services/separationDates.test.js
+++ b/app/services/separationDates.test.js
@@ -17,7 +17,7 @@ describe(modulePath, () => {
   let session = {};
 
   beforeEach(() => {
-    timekeeper.freeze(new Date('04/01/2000'));
+    timekeeper.freeze(new Date('2001-05-01T11:00:00Z'));
   });
 
   afterEach(() => {
@@ -50,7 +50,7 @@ describe(modulePath, () => {
         reasonForDivorceLivingApartDate: separationDate
       };
 
-      expect('3 months, 2 weeks and 2 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+      expect('3 months, 2 weeks and 3 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
     });
 
     it('should return month, week and day when time together permitted is less than 6 months', () => {

--- a/app/services/separationDates.test.js
+++ b/app/services/separationDates.test.js
@@ -92,7 +92,7 @@ describe(modulePath, () => {
       expect('2 weeks and 2 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
     });
 
-    it('should return month, week and day when time together permitted is less than 6 months', () => {
+    it('should return week and day when time together permitted is less than 6 months', () => {
       const separationDate = moment().startOf(constants.days)
         .subtract(5, constants.years)
         .subtract(1, constants.weeks)
@@ -104,6 +104,32 @@ describe(modulePath, () => {
       };
 
       expect('1 week and 1 day').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return only week when time together permitted is less than 6 months', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(1, constants.weeks);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('1 week').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return only day when time together permitted is less than 6 months', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(1, constants.days);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('1 day').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
     });
   });
 });

--- a/app/services/separationDates.test.js
+++ b/app/services/separationDates.test.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-magic-numbers */
+const moment = require('moment');
+const timekeeper = require('timekeeper');
+const { expect } = require('test/util/chai');
+
+const modulePath = 'app/services/separationDates';
+const underTest = require(modulePath);
+
+const constants = {
+  days: 'days',
+  weeks: 'weeks',
+  months: 'months',
+  years: 'years'
+};
+
+describe(modulePath, () => {
+  let session = {};
+
+  beforeEach(() => {
+    timekeeper.freeze(new Date('04/01/2000'));
+  });
+
+  afterEach(() => {
+    timekeeper.reset();
+  });
+
+  describe('getSeparationTimeTogetherPermitted', () => {
+    it('should return more than 6 months when time together permitted is greater than six', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(9, constants.months);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('6 months').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return months, weeks and days when time together permitted is less than 6 months', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(3, constants.months)
+        .subtract(2, constants.weeks)
+        .subtract(2, constants.days);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('3 months, 2 weeks and 2 days').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+
+    it('should return month, week and day when time together permitted is less than 6 months', () => {
+      const separationDate = moment().startOf(constants.days)
+        .subtract(5, constants.years)
+        .subtract(1, constants.months)
+        .subtract(1, constants.weeks)
+        .subtract(1, constants.days);
+      session = {
+        reasonForDivorce: 'separation-5-years',
+        reasonForDivorceDecisionDate: separationDate,
+        reasonForDivorceLivingApartDate: separationDate
+      };
+
+      expect('1 month, 1 week and 1 day').to.equal(underTest.getSeparationTimeTogetherPermitted(session));
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "stryker-mocha-framework": "^0.9.1",
     "stryker-mocha-runner": "^0.11.1",
     "supertest": "^2.0.0",
+    "timekeeper": "^2.1.2",
     "unirest": "^0.5.1",
     "w3c-validate": "0.0.2",
     "webdriverio": "^4.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10117,6 +10117,11 @@ timed-out@^4.0.0:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
+timekeeper@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.1.2.tgz#0fd98dd839551f2ab6b92b283754ea5a24edc901"
+  integrity sha512-fc1DDqbiyz5vxRO4xkiATwfWUw1FV7W20+FJYal1SnoIYgNuB4WNxYLtbG3zjUBwOSk3P4u1TgBAZYG/aqBWMw==
+
 timers-browserify@^2.0.4:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"


### PR DESCRIPTION
…eparations

Bug:

Was returning separation date instead of more than 6 months when separation date between mental and physical was greater than 6 months overall.
This fixes the text.