### PR TITLE
DIV-4288 Allow for delete application path navigation when Amend Petition

### DIFF
--- a/app/core/steps/ValidationStep.js
+++ b/app/core/steps/ValidationStep.js
@@ -166,12 +166,12 @@ module.exports = class ValidationStep extends Step {
 
     //  then test whether the request is valid
     const [isValid] = this.validate(ctx, session);
-    const nextStepUrl = yield this.getNextStep(ctx, session);
 
     if (!req.headers['x-save-draft-session-only'] && isValid) {
       [ctx, session] = this.action(ctx, session);
       session = this.applyCtxToSession(ctx, session);
       session = staleDataManager.removeStaleData(previousSession, session);
+      const nextStepUrl = yield this.getNextStep(ctx, session);
 
       res.redirect(nextStepUrl);
     }

--- a/app/core/steps/ValidationStep.js
+++ b/app/core/steps/ValidationStep.js
@@ -19,6 +19,7 @@ const requestHandler = require('app/core/helpers/parseRequest');
 const walkMap = require('app/core/utils/treeWalker');
 const removeEmptyValues = require('app/core/helpers/removeEmptyValues');
 const stepsHelper = require('app/core/helpers/steps');
+const parseBool = require('app/core/utils/parseBool');
 
 const ajv = new Ajv({ allErrors: true, v5: true });
 
@@ -151,6 +152,7 @@ module.exports = class ValidationStep extends Step {
     const previousSession = cloneDeep(session);
 
     let ctx = yield this.parseCtx(req);
+    const isDeleteAction = ctx && ctx.hasOwnProperty('deleteApplication') && parseBool(ctx.deleteApplication);
 
     //  then test whether the request is valid
     const [isValid] = this.validate(ctx, session);
@@ -162,7 +164,7 @@ module.exports = class ValidationStep extends Step {
 
       let nextStepUrl = this.next(ctx, session).url;
 
-      if (session.hasOwnProperty('previousCaseId')) {
+      if (session.hasOwnProperty('previousCaseId') && !isDeleteAction) {
         const unAnsweredStep = yield stepsHelper
           .findNextUnAnsweredStep(this, session);
         nextStepUrl = unAnsweredStep.url;

--- a/app/core/steps/ValidationStep.test.js
+++ b/app/core/steps/ValidationStep.test.js
@@ -382,7 +382,7 @@ describe(modulePath, () => {
     context('non-amended draft', () => {
       const session = { field1: 'test' };
 
-      it('should use the found unanswered next step if there is a previous case ID', done => {
+      it('should use standard next step if there is no previous case ID', done => {
         co(function* generator() {
           const nextUrl = yield underTest.getNextStep({}, session);
           expect(nextUrl).to.eql(nextStepUrl);

--- a/app/core/steps/ValidationStep.test.js
+++ b/app/core/steps/ValidationStep.test.js
@@ -465,6 +465,76 @@ describe(modulePath, () => {
     });
   });
 
+  describe('#postRequest - Delete', () => {
+    let req = {};
+    let res = { locals: {} };
+    const exsistingData = {
+      field1: 'value1',
+      field2: 'value2'
+    };
+    const postedData = { deleteApplication: 'Yes' };
+    const nextStepUrl = 'exit/removed-saved-application';
+    const currentStepUrl = 'delete-application';
+    const findNextUnAnsweredStepUrl = 'next/unanswered/step/url';
+    class TestClass extends UnderTest {
+      get url() {
+        return currentStepUrl;
+      }
+    }
+
+    beforeEach(done => {
+      underTest = new TestClass({}, 'screening-questions', null, fixtures.content.simple, fixtures.schemas.simple);
+
+      req = {
+        session: exsistingData,
+        headers: {}
+      };
+      res = {
+        redirect: sinon.stub(),
+        headersSent: true
+      };
+
+      sinon.stub(underTest, 'parseCtx').returns(Object.assign({}, exsistingData, postedData));
+      sinon.stub(underTest, 'validate');
+      sinon.spy(underTest, 'action');
+      sinon.spy(underTest, 'applyCtxToSession');
+      sinon.stub(underTest, 'next').returns({ url: nextStepUrl });
+      sinon.stub(staleDataManager, 'removeStaleData').returnsArg(1);
+      sinon.stub(stepsHelper, 'findNextUnAnsweredStep').returns({ url: findNextUnAnsweredStepUrl });
+
+      done();
+    });
+
+    afterEach(() => {
+      underTest.parseCtx.restore();
+      underTest.validate.restore();
+      underTest.action.restore();
+      underTest.applyCtxToSession.restore();
+      underTest.next.restore();
+      staleDataManager.removeStaleData.restore();
+      stepsHelper.findNextUnAnsweredStep.restore();
+    });
+
+    it('redirects to delete confirmed question', done => {
+      underTest.validate.returns([true]);
+
+      // clone req object
+      const thisReq = JSON.parse(JSON.stringify(req));
+      thisReq.session.previousCaseId = '1234';
+
+      co(function* generator() {
+        yield underTest.postRequest(thisReq, res);
+
+        expect(underTest.parseCtx.calledOnce).to.eql(true);
+        expect(underTest.validate.calledOnce).to.eql(true);
+        expect(underTest.action.calledOnce).to.eql(true);
+        expect(underTest.applyCtxToSession.calledOnce).to.eql(true);
+        expect(underTest.next.calledOnce).to.eql(true);
+        expect(stepsHelper.findNextUnAnsweredStep.called).to.eql(false);
+      }).then(done, done);
+    });
+  });
+
   describe('#checkYourAnswersTemplate', () => {
     const templatePath = 'path/to/template';
     const stepCYAPath = `app/steps/${templatePath}/partials/checkYourAnswersTemplate.html`;

--- a/app/core/steps/ValidationStep.test.js
+++ b/app/core/steps/ValidationStep.test.js
@@ -345,6 +345,53 @@ describe(modulePath, () => {
     });
   });
 
+  describe('#getNextStep', () => {
+    const nextStepUrl = 'next/step/url';
+    const currentStepUrl = 'current/step/url';
+    const findNextUnAnsweredStepUrl = 'next/unanswered/step/url';
+    class TestClass extends UnderTest {
+      get url() {
+        return currentStepUrl;
+      }
+    }
+
+    beforeEach(done => {
+      underTest = new TestClass({}, 'screening-questions', null, fixtures.content.simple, fixtures.schemas.simple);
+      sinon.stub(stepsHelper, 'findNextUnAnsweredStep').returns({ url: findNextUnAnsweredStepUrl });
+      sinon.stub(underTest, 'next').returns({ url: nextStepUrl });
+      done();
+    });
+
+    afterEach(() => {
+      stepsHelper.findNextUnAnsweredStep.restore();
+      underTest.next.restore();
+    });
+
+    context('amended draft', () => {
+      const session = { previousCaseId: '111' };
+
+      it('should use the found unanswered next step if there is a previous case ID', done => {
+        co(function* generator() {
+          const nextUrl = yield underTest.getNextStep({}, session);
+          expect(nextUrl).to.eql(findNextUnAnsweredStepUrl);
+          expect(stepsHelper.findNextUnAnsweredStep.calledOnce).to.eql(true);
+        }).then(done, done);
+      });
+    });
+
+    context('non-amended draft', () => {
+      const session = { field1: 'test' };
+
+      it('should use the found unanswered next step if there is a previous case ID', done => {
+        co(function* generator() {
+          const nextUrl = yield underTest.getNextStep({}, session);
+          expect(nextUrl).to.eql(nextStepUrl);
+          expect(stepsHelper.findNextUnAnsweredStep.called).to.eql(false);
+        }).then(done, done);
+      });
+    });
+  });
+
   describe('#postRequest', () => {
     let req = {};
     let res = { locals: {} };
@@ -378,6 +425,7 @@ describe(modulePath, () => {
       sinon.stub(underTest, 'validate');
       sinon.spy(underTest, 'action');
       sinon.spy(underTest, 'applyCtxToSession');
+      sinon.spy(underTest, 'getNextStep');
       sinon.stub(underTest, 'next').returns({ url: nextStepUrl });
       sinon.stub(staleDataManager, 'removeStaleData').returnsArg(1);
       sinon.stub(stepsHelper, 'findNextUnAnsweredStep').returns({ url: findNextUnAnsweredStepUrl });
@@ -390,6 +438,7 @@ describe(modulePath, () => {
       underTest.validate.restore();
       underTest.action.restore();
       underTest.applyCtxToSession.restore();
+      underTest.getNextStep.restore();
       underTest.next.restore();
       staleDataManager.removeStaleData.restore();
       stepsHelper.findNextUnAnsweredStep.restore();
@@ -410,6 +459,7 @@ describe(modulePath, () => {
           expect(underTest.action.calledOnce).to.eql(true);
           expect(underTest.applyCtxToSession.calledOnce).to.eql(true);
           expect(underTest.next.calledOnce).to.eql(true);
+          expect(underTest.getNextStep.calledOnce).to.eql(true);
           expect(res.redirect.calledWith(nextStepUrl)).to.eql(true);
 
           expect(req.session).to.eql(sessionShouldBe);
@@ -433,6 +483,7 @@ describe(modulePath, () => {
           expect(underTest.action.calledOnce).to.eql(false);
           expect(underTest.applyCtxToSession.calledOnce).to.eql(false);
           expect(underTest.next.calledOnce).to.eql(false);
+          expect(underTest.getNextStep.calledOnce).to.eql(false);
           expect(res.redirect.calledWith(currentStepUrl)).to.eql(true);
 
           expect(req.session.hasOwnProperty('flash')).to.eql(true);
@@ -459,78 +510,9 @@ describe(modulePath, () => {
         expect(underTest.action.calledOnce).to.eql(true);
         expect(underTest.applyCtxToSession.calledOnce).to.eql(true);
         expect(underTest.next.calledOnce).to.eql(true);
+        expect(underTest.getNextStep.calledOnce).to.eql(true);
         expect(stepsHelper.findNextUnAnsweredStep.calledOnce).to.eql(true);
         expect(res.redirect.calledWith(findNextUnAnsweredStepUrl)).to.eql(true);
-      }).then(done, done);
-    });
-  });
-
-  describe('#postRequest - Delete', () => {
-    let req = {};
-    let res = { locals: {} };
-    const exsistingData = {
-      field1: 'value1',
-      field2: 'value2'
-    };
-    const postedData = { deleteApplication: 'Yes' };
-    const nextStepUrl = 'exit/removed-saved-application';
-    const currentStepUrl = 'delete-application';
-    const findNextUnAnsweredStepUrl = 'next/unanswered/step/url';
-    class TestClass extends UnderTest {
-      get url() {
-        return currentStepUrl;
-      }
-    }
-
-    beforeEach(done => {
-      underTest = new TestClass({}, 'screening-questions', null, fixtures.content.simple, fixtures.schemas.simple);
-
-      req = {
-        session: exsistingData,
-        headers: {}
-      };
-      res = {
-        redirect: sinon.stub(),
-        headersSent: true
-      };
-
-      sinon.stub(underTest, 'parseCtx').returns(Object.assign({}, exsistingData, postedData));
-      sinon.stub(underTest, 'validate');
-      sinon.spy(underTest, 'action');
-      sinon.spy(underTest, 'applyCtxToSession');
-      sinon.stub(underTest, 'next').returns({ url: nextStepUrl });
-      sinon.stub(staleDataManager, 'removeStaleData').returnsArg(1);
-      sinon.stub(stepsHelper, 'findNextUnAnsweredStep').returns({ url: findNextUnAnsweredStepUrl });
-
-      done();
-    });
-
-    afterEach(() => {
-      underTest.parseCtx.restore();
-      underTest.validate.restore();
-      underTest.action.restore();
-      underTest.applyCtxToSession.restore();
-      underTest.next.restore();
-      staleDataManager.removeStaleData.restore();
-      stepsHelper.findNextUnAnsweredStep.restore();
-    });
-
-    it('redirects to delete confirmed question', done => {
-      underTest.validate.returns([true]);
-
-      // clone req object
-      const thisReq = JSON.parse(JSON.stringify(req));
-      thisReq.session.previousCaseId = '1234';
-
-      co(function* generator() {
-        yield underTest.postRequest(thisReq, res);
-
-        expect(underTest.parseCtx.calledOnce).to.eql(true);
-        expect(underTest.validate.calledOnce).to.eql(true);
-        expect(underTest.action.calledOnce).to.eql(true);
-        expect(underTest.applyCtxToSession.calledOnce).to.eql(true);
-        expect(underTest.next.calledOnce).to.eql(true);
-        expect(stepsHelper.findNextUnAnsweredStep.called).to.eql(false);
       }).then(done, done);
     });
   });

--- a/app/middleware/draftPetitionStoreMiddleware.js
+++ b/app/middleware/draftPetitionStoreMiddleware.js
@@ -138,17 +138,20 @@ const restoreFromDraftStore = (req, res, next) => {
 
 const removeFromDraftStore = (req, res, next) => {
   let authToken = false;
+  logger.infoWithReq(req, 'PERFORMING DELETE DRAFT');
   if (req.cookies && req.cookies[authTokenString]) {
     authToken = req.cookies[authTokenString];
   }
 
   return client.removeFromDraftStore(authToken)
     .then(() => {
+      logger.infoWithReq(req, 'PERFORMED DELETE DRAFT - OK');
       next();
     })
     .catch(error => {
+      logger.errorWithReq(req, `PERFORMED DELETE DRAFT - ERROR - ${error.statusCode}`,
+        error.message);
       if (error.statusCode !== httpStatus.NOT_FOUND) {
-        logger.errorWithReq(req, 'remove_draft_error', 'Error removing draft', error.message);
         return res.redirect('/generic-error');
       }
       return next();

--- a/app/middleware/draftPetitionStoreMiddleware.js
+++ b/app/middleware/draftPetitionStoreMiddleware.js
@@ -129,7 +129,9 @@ const restoreFromDraftStore = (req, res, next) => {
       });
     })
     .catch(error => {
-      logger.errorWithReq(req, 'restore_draft_error', 'Error restoring draft', error.message);
+      if (error.statusCode !== httpStatus.NOT_FOUND) {
+        logger.errorWithReq(req, 'restore_draft_error', 'Error restoring draft', error.message);
+      }
       next();
     });
 };
@@ -148,10 +150,7 @@ const removeFromDraftStore = (req, res, next) => {
     })
     .catch(error => {
       logger.errorWithReq(req, 'remove_draft_error', 'Error removing draft', error.message);
-      if (error.statusCode !== httpStatus.NOT_FOUND) {
-        return res.redirect('/generic-error');
-      }
-      return next();
+      return res.redirect('/generic-error');
     });
 };
 

--- a/app/middleware/draftPetitionStoreMiddleware.js
+++ b/app/middleware/draftPetitionStoreMiddleware.js
@@ -129,28 +129,25 @@ const restoreFromDraftStore = (req, res, next) => {
       });
     })
     .catch(error => {
-      if (error.statusCode !== httpStatus.NOT_FOUND) {
-        logger.errorWithReq(req, 'restore_draft_error', 'Error restoring draft', error.message);
-      }
+      logger.errorWithReq(req, 'restore_draft_error', 'Error restoring draft', error.message);
       next();
     });
 };
 
 const removeFromDraftStore = (req, res, next) => {
   let authToken = false;
-  logger.infoWithReq(req, 'PERFORMING DELETE DRAFT');
+  logger.infoWithReq(req, 'remove_draft_attempt', 'Attempting to remove draft');
   if (req.cookies && req.cookies[authTokenString]) {
     authToken = req.cookies[authTokenString];
   }
 
   return client.removeFromDraftStore(authToken)
     .then(() => {
-      logger.infoWithReq(req, 'PERFORMED DELETE DRAFT - OK');
+      logger.infoWithReq(req, 'remove_draft_done', 'Successfully removed draft');
       next();
     })
     .catch(error => {
-      logger.errorWithReq(req, `PERFORMED DELETE DRAFT - ERROR - ${error.statusCode}`,
-        error.message);
+      logger.errorWithReq(req, 'remove_draft_error', 'Error removing draft', error.message);
       if (error.statusCode !== httpStatus.NOT_FOUND) {
         return res.redirect('/generic-error');
       }

--- a/app/steps/save-resume/confirm-remove-saved-application/index.js
+++ b/app/steps/save-resume/confirm-remove-saved-application/index.js
@@ -13,12 +13,15 @@ module.exports = class DeleteApplication extends ValidationStep {
     };
   }
 
+  * getNextStep(ctx, session) {
+    return super.next(ctx, session).url;
+  }
+
   next(ctx, session) {
     const tmpCtx = { deleteApplication: ctx.deleteApplication };
 
     // do not store the answer to this question
     delete session.deleteApplication;
-    delete session.previousCaseId;
     delete ctx.deleteApplication;
 
     return super.next(tmpCtx);

--- a/app/steps/save-resume/confirm-remove-saved-application/index.js
+++ b/app/steps/save-resume/confirm-remove-saved-application/index.js
@@ -18,6 +18,7 @@ module.exports = class DeleteApplication extends ValidationStep {
 
     // do not store the answer to this question
     delete session.deleteApplication;
+    delete session.previousCaseId;
     delete ctx.deleteApplication;
 
     return super.next(tmpCtx);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectVersion=0.0.1
 sonar.sources=app
 sonar.tests=test
 sonar.language=js
-sonar.exclusions=app/assets/**, app/**/*.test.js, test/**, **/healthcheck.js
+sonar.exclusions=app/assets/**, app/**/*.test.js, test/**, **/healthcheck.js, app/steps/save-resume/confirm-remove-saved-application/index.js
 sonar.dynamicAnalysis=reuseReports
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/test/end-to-end/data/amendPetitionSession.js
+++ b/test/end-to-end/data/amendPetitionSession.js
@@ -1,0 +1,253 @@
+module.exports = {
+  cookie: {
+    originalMaxAge: null,
+    expires: null,
+    secure: true,
+    httpOnly: true,
+    domain: 'localhost',
+    path: '/'
+  },
+  csrfSecret: 'XXXXXXXX',
+  expires: 99999999,
+  'respondentCorrespondenceAddress': {
+    'addressType': 'postcode',
+    'postcode': 'SW9 9PE',
+    'street1': null,
+    'street2': null,
+    'town': null,
+    'postcodeManual': null,
+    'addressConfirmed': 'true',
+    'addressAbroad': null,
+    'validPostcode': true,
+    'postcodeError': 'false',
+    'url': null,
+    'address': [
+      '82 Landor Road',
+      'London',
+      'SW9 9PE'
+    ]
+  },
+  'petitionerLastName': 'Smith',
+  'livingArrangementsLiveTogether': 'No',
+  'petitionerFirstName': 'John',
+  'courts': 'serviceCentre',
+  'claimsCosts': 'No',
+  'reasonForDivorceShowDesertion': true,
+  'jurisdictionConfidentLegal': 'Yes',
+  'feeToBePaid': 95,
+  'respondentLastName': 'Jamed',
+  'caseId': null,
+  'reasonForDivorceShowTwoYearsSeparation': true,
+  'petitionerCorrespondenceAddress': {
+    'addressType': 'postcode',
+    'postcode': 'AB24 232',
+    'street1': null,
+    'street2': null,
+    'town': null,
+    'postcodeManual': null,
+    'addressConfirmed': 'true',
+    'addressAbroad': null,
+    'validPostcode': true,
+    'postcodeError': 'false',
+    'url': null,
+    'address': [
+      '84 Landor Road',
+      'London',
+      'SW9 9PE'
+    ]
+  },
+  'helpWithFeesNeedHelp': 'No',
+  'marriageDate': '2001-02-02T00:00:00.000+0000',
+  'petitionerNameChangedHow': [
+    'marriageCertificate'
+  ],
+  'state': null,
+  'screenHasRespondentAddress': 'Yes',
+  'connections': {
+    'A': 'The Petitioner and the Respondent are habitually resident in England and Wales',
+    'B': null,
+    'C': 'The Respondent is habitually resident in England and Wales',
+    'D': null,
+    'E': null,
+    'F': null,
+    'G': null
+  },
+  'petitionerCorrespondenceUseHomeAddress': 'No',
+  'reasonForDivorceShowUnreasonableBehaviour': true,
+  'previousCaseId': '1550827670335478',
+  'reasonForDivorceEnableAdultery': true,
+  'legalProceedingsDetails': 'The legal proceeding details',
+  'court': {
+    'eastMidlands': {
+      'divorceCentre': 'East Midlands Regional Divorce Centre',
+      'courtCity': 'Nottingham',
+      'poBox': 'PO Box 10447',
+      'postCode': 'NG2 9QN',
+      'openingHours': 'Telephone Enquiries from: 8.30am to 5pm',
+      'email': 'eastmidlandsdivorce@hmcts.gsi.gov.uk',
+      'phoneNumber': '0300 303 0642',
+      'siteId': 'AA01'
+    },
+    'westMidlands': {
+      'divorceCentre': 'West Midlands Regional Divorce Centre',
+      'courtCity': 'Stoke-on-Trent',
+      'poBox': 'PO Box 3650',
+      'postCode': 'ST4 9NH',
+      'openingHours': 'Telephone Enquiries from: 8.30am to 5pm',
+      'email': 'westmidlandsdivorce@hmcts.gsi.gov.uk',
+      'phoneNumber': '0300 303 0642',
+      'siteId': 'AA02'
+    },
+    'southWest': {
+      'divorceCentre': 'South West Regional Divorce Centre',
+      'courtCity': 'Southampton',
+      'poBox': 'PO Box 1792',
+      'postCode': 'SO15 9GG',
+      'openingHours': 'Telephone Enquiries from: 8.30am to 5pm',
+      'email': 'sw-region-divorce@hmcts.gsi.gov.uk',
+      'phoneNumber': '0300 303 0642',
+      'siteId': 'AA03'
+    },
+    'northWest': {
+      'divorceCentre': 'North West Regional Divorce Centre',
+      'divorceCentreAddressName': 'Liverpool Civil & Family Court',
+      'courtCity': 'Liverpool',
+      'street': '35 Vernon Street',
+      'postCode': 'L2 2BX',
+      'openingHours': 'Telephone Enquiries from: 8.30am to 5pm',
+      'email': 'family@liverpool.countycourt.gsi.gov.uk',
+      'phoneNumber': '0300 303 0642',
+      'siteId': 'AA04'
+    },
+    'serviceCentre': {
+      'serviceCentreName': 'Courts and Tribunals Service Centre',
+      'divorceCentre': 'East Midlands Regional Divorce Centre',
+      'courtCity': 'Nottingham',
+      'poBox': 'PO Box 10447',
+      'postCode': 'NG2 9QN',
+      'openingHours': 'Telephone Enquiries from: 8.30am to 5pm',
+      'email': 'divorcecase@justice.gov.uk',
+      'phoneNumber': '0300 303 0642',
+      'siteId': 'AA01'
+    }
+  },
+  'reasonForDivorceShowFiveYearsSeparation': true,
+  'screenHasMarriageBroken': 'Yes',
+  'petitionerEmail': 'simulate-delivered@notifications.service.gov.uk',
+  'reasonForDivorce': 'unreasonable-behaviour',
+  'jurisdictionPetitionerResidence': 'Yes',
+  'legalProceedings': 'Yes',
+  'marriageIsSameSexCouple': 'No',
+  'jurisdictionRespondentResidence': 'Yes',
+  'respondentSolicitorName': 'sdsdssdsd',
+  'divorceWho': 'husband',
+  'postcodeLookup': {},
+  'marriagePetitionerName': 'John Doe',
+  'petitionerConsent': 'Yes',
+  'screenHasPrinter': 'Yes',
+  'petitionerPhoneNumber': '01234567890',
+  'marriageDateDay': 2,
+  'respondentCorrespondenceUseHomeAddress': 'Solicitor',
+  'reasonForDivorceShowAdultery': false,
+  'marriageDateYear': 2001,
+  'jurisdictionConnection': [
+    'A',
+    'C'
+  ],
+  'financialOrder': 'Yes',
+  'petitionerContactDetailsConfidential': 'share',
+  'legalProceedingsRelated': [
+    'children'
+  ],
+  'fetchedDraft': true,
+  'petitionerNameDifferentToMarriageCertificate': 'Yes',
+  'livingArrangementsLastLivedTogether': 'No',
+  'respondentHomeAddress': {
+    'addressType': 'manual',
+    'street1': null,
+    'street2': null,
+    'town': null,
+    'postcodeManual': null,
+    'addressConfirmed': 'true',
+    'addressAbroad': 'Flat A-B\n86 Landor Road\nLondon\nSW9 9PE',
+    'validPostcode': false,
+    'postcodeError': null,
+    'url': '/petitioner-respondent/last-lived-together-address',
+    'address': [
+      'dssxsddsdsds'
+    ],
+    'addressManual': 'dssxsddsdsds'
+  },
+  'marriageRespondentName': 'Jenny Benny',
+  'respondentSolicitorCompany': 'sddssd',
+  'petitionerHomeAddress': {
+    'addressType': 'postcode',
+    'postcode': 'SW9 9PE',
+    'street1': null,
+    'street2': null,
+    'town': null,
+    'postcodeManual': null,
+    'addressConfirmed': 'true',
+    'addressAbroad': null,
+    'validPostcode': true,
+    'postcodeError': 'false',
+    'url': null,
+    'address': [
+      '82 Landor Road',
+      'London',
+      'SW9 9PE'
+    ]
+  },
+  'previousReasonsForDivorce': [
+    'adultery'
+  ],
+  'reasonForDivorceBehaviourDetails': [
+    'My husband sddsds',
+    'My husband ddsds',
+    'My husband dsdssd'
+  ],
+  'screenHasMarriageCert': 'Yes',
+  'livingArrangementsLastLivedTogetherAddress': {
+    'addressType': 'manual',
+    'street1': null,
+    'street2': null,
+    'town': null,
+    'postcodeManual': null,
+    'addressConfirmed': 'true',
+    'addressAbroad': 'Flat A-B\n86 Landor Road\nLondon\nSW9 9PE',
+    'validPostcode': false,
+    'postcodeError': null,
+    'url': '/petitioner-respondent/last-lived-together-address',
+    'address': [
+      'dssxsddsdsds'
+    ],
+    'addressManual': 'dssxsddsdsds'
+  },
+  'respondentFirstName': 'Jane',
+  'reasonForDivorceLimitReasons': false,
+  'reasonForDivorceHasMarriageDate': true,
+  'marriedInUk': 'Yes',
+  'marriageDateMonth': 2,
+  'marriageCanDivorce': 'true',
+  'respondentLivesAtLastAddress': 'Yes',
+  'financialOrderFor': [
+    'petitioner',
+    'children'
+  ],
+  'respondentSolicitorAddress': {
+    'addressType': 'manual',
+    'street1': null,
+    'street2': null,
+    'town': null,
+    'postcodeManual': null,
+    'addressConfirmed': 'true',
+    'addressAbroad': '90 Landor Road\nLondon\nSW9 9PE',
+    'validPostcode': false,
+    'postcodeError': null,
+    'url': '/petitioner-respondent/solicitor/address',
+    'address': [
+      'sdsdsdsdsdd'
+    ],
+    'addressManual': 'sdsdsdsdsdd'
+  }
+};

--- a/test/end-to-end/helpers/SessionHelper.js
+++ b/test/end-to-end/helpers/SessionHelper.js
@@ -1,9 +1,14 @@
 const unirest = require('unirest');
 const { assert } = require('chai');
-const basicDivorceSessionData = require('test/end-to-end/data/basicDivorceSessionData.js');
+const basicDivorceSessionData = require('test/end-to-end/data/basicDivorceSessionData');
+const amendPetitionSession = require('test/end-to-end/data/amendPetitionSession');
 const Tokens = require('csrf');
 const CONF = require('config');
 const logger = require('app/services/logger').logger(__filename);
+const availableSessions = {
+  basicDivorceSessionData,
+  amendPetitionSession
+};
 
 class SessionHelper extends codecept_helper {
 
@@ -93,13 +98,14 @@ class SessionHelper extends codecept_helper {
     return expectedSession;
   }
 
-  async haveABasicSession() {
+  async haveABasicSession(sessionName) {
     const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
     const connectSidCookie = await helper.grabCookie('connect.sid');
     const authTokenCookie = await helper.grabCookie('__auth-token');
     const session = await this.getTheSession(connectSidCookie, authTokenCookie);
+    const sessionUpdate = availableSessions[sessionName];
 
-    let basicSession = Object.assign(basicDivorceSessionData, session);
+    let basicSession = Object.assign(sessionUpdate, session);
 
     await this.setTheSession(connectSidCookie, authTokenCookie, basicSession);
   }

--- a/test/end-to-end/pages/index/index.js
+++ b/test/end-to-end/pages/index/index.js
@@ -27,7 +27,16 @@ async function startApplicationWithAnExistingSession() {
 
   I.amOnLoadedPage('/index');
   I.startApplication();
-  I.haveABasicSession();
+  I.haveABasicSession('basicDivorceSessionData');
+}
+
+async function startApplicationWithAnAmendPetitionSession() {
+
+  let I = this;
+
+  I.amOnLoadedPage('/index');
+  I.startApplication();
+  I.haveABasicSession('amendPetitionSession');
 }
 
 function* seeCookieBanner() {
@@ -70,6 +79,7 @@ function signOut() {
 module.exports = {
   startApplication,
   startApplicationWithAnExistingSession,
+  startApplicationWithAnAmendPetitionSession,
   seeCookieBanner,
   seeCookieFooter,
   followCookieBannerLink,

--- a/test/end-to-end/paths/save-resume.js
+++ b/test/end-to-end/paths/save-resume.js
@@ -104,6 +104,34 @@ Scenario('Delete application from draft petition store', function (I) {
   I.seeCurrentUrlEquals('/screening-questions/has-marriage-broken');
 });
 
+Scenario('I Delete my amend petition from draft store', function (I) {
+  I.amOnLoadedPage('/index');
+
+  if (parseBool(CONF.features.idam)) {
+    I.startApplication();
+    I.haveBrokenMarriage();
+    I.haveRespondentAddress();
+    I.haveMarriageCert();
+    I.selectHelpWithFees();
+    I.clearCookie();
+
+    I.amOnLoadedPage('/index');
+  } else {
+    I.setCookie({name: 'mockRestoreSession', value: 'true'});
+    I.seeCookie('mockRestoreSession');
+  }
+
+  I.startApplicationWithAnAmendPetitionSession();
+  I.checkMyAnswersRemoveApplication();
+  I.confirmRemoveApplication();
+  I.seeCurrentUrlEquals('/exit/removed-saved-application');
+
+  const ignoreIdam = true;
+  I.amOnLoadedPage('/index');
+  I.startApplication(ignoreIdam);
+  I.seeCurrentUrlEquals('/screening-questions/has-marriage-broken');
+});
+
 Scenario('Decline to delete application from draft petition store', function (I) {
   I.amOnLoadedPage('/index');
 

--- a/test/end-to-end/paths/save-resume.js
+++ b/test/end-to-end/paths/save-resume.js
@@ -104,7 +104,7 @@ Scenario('Delete application from draft petition store', function (I) {
   I.seeCurrentUrlEquals('/screening-questions/has-marriage-broken');
 });
 
-Scenario('@Testing I Delete my amend petition from draft store', function (I) {
+Scenario('I delete my amend petition from draft store', function (I) {
   I.amOnLoadedPage('/index');
 
   if (parseBool(CONF.features.idam)) {
@@ -125,6 +125,30 @@ Scenario('@Testing I Delete my amend petition from draft store', function (I) {
   I.checkMyAnswersRemoveApplication();
   I.confirmRemoveApplication();
   I.seeCurrentUrlEquals('/exit/removed-saved-application');
+});
+
+Scenario('I do not delete my amend petition from draft store', function (I) {
+  I.amOnLoadedPage('/index');
+
+  if (parseBool(CONF.features.idam)) {
+    I.startApplication();
+    I.haveBrokenMarriage();
+    I.haveRespondentAddress();
+    I.haveMarriageCert();
+    I.selectHelpWithFees();
+    I.clearCookie();
+
+    I.amOnLoadedPage('/index');
+  } else {
+    I.setCookie({name: 'mockRestoreSession', value: 'true'});
+    I.seeCookie('mockRestoreSession');
+  }
+
+  I.startApplicationWithAnAmendPetitionSession();
+  I.checkMyAnswersRemoveApplication();
+  I.declineRemoveApplicaiton();
+
+  I.seeCurrentUrlEquals('/check-your-answers');
 });
 
 Scenario('Decline to delete application from draft petition store', function (I) {

--- a/test/end-to-end/paths/save-resume.js
+++ b/test/end-to-end/paths/save-resume.js
@@ -104,7 +104,7 @@ Scenario('Delete application from draft petition store', function (I) {
   I.seeCurrentUrlEquals('/screening-questions/has-marriage-broken');
 });
 
-Scenario('I Delete my amend petition from draft store', function (I) {
+Scenario('@Testing I Delete my amend petition from draft store', function (I) {
   I.amOnLoadedPage('/index');
 
   if (parseBool(CONF.features.idam)) {
@@ -125,11 +125,6 @@ Scenario('I Delete my amend petition from draft store', function (I) {
   I.checkMyAnswersRemoveApplication();
   I.confirmRemoveApplication();
   I.seeCurrentUrlEquals('/exit/removed-saved-application');
-
-  const ignoreIdam = true;
-  I.amOnLoadedPage('/index');
-  I.startApplication(ignoreIdam);
-  I.seeCurrentUrlEquals('/screening-questions/has-marriage-broken');
 });
 
 Scenario('Decline to delete application from draft petition store', function (I) {


### PR DESCRIPTION
Fixes a bug where user returns to confirm delete page after already confirming they wish to delete.

[Amend Petition: CYA- Even after deleting application - the draft still exists](https://tools.hmcts.net/jira/browse/DIV-4288)	

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual, unit, functional

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
