### PR TITLE
Temporarily disable payment callback url being used

### DIFF
--- a/app/services/payment.js
+++ b/app/services/payment.js
@@ -15,6 +15,8 @@ const service = {
    */
   create: (req, user, serviceToken, caseReference, siteId, feeCode,
     feeVersion, amountInput, description, returnUrl, serviceCallbackUrl) => {
+    // Temporarily disable sending serviceCallbackUrl
+    serviceCallbackUrl = ''; // eslint-disable-line
     return client.create(user, serviceToken, caseReference, siteId, feeCode,
       feeVersion, amountInput, description, returnUrl, serviceCallbackUrl)
       .then(response => {


### PR DESCRIPTION
To possibly resolve the heavy cpu usage issue in prod, until an actual solution is put into place.