### PR TITLE
Migrated grunt-sync to grunt-contrib-copy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,25 +22,29 @@ module.exports = function(grunt) {
       }
     },
 
-    sync: {
-      assets: {
+    copy: {
+      main: {
         files: [
           {
+            expand: true,
             cwd: 'app/assets/sass',
             src: '**',
             dest: 'tmp/sass/'
           },
           {
+            expand: true,
             cwd: 'app/assets/images',
             src: '**',
             dest: 'tmp/images/'
           },
           {
+            expand: true,
             cwd: 'node_modules/govuk_template_mustache/assets/images',
             src: '**',
             dest: 'tmp/images/'
           },
           {
+            expand: true,
             cwd: 'node_modules/govuk_frontend_toolkit/images',
             src: '**',
             dest: 'tmp/images/'
@@ -88,7 +92,7 @@ module.exports = function(grunt) {
 
   [
     'grunt-contrib-clean',
-    'grunt-sync',
+    'grunt-contrib-copy',
     'grunt-contrib-watch',
     'grunt-nodemon',
     'grunt-concurrent',
@@ -100,13 +104,13 @@ module.exports = function(grunt) {
   grunt.registerTask('setup-assets', ['webpack:assets']);
 
   grunt.registerTask('setup-prod', [
-    'sync',
+    'copy',
     'webpack:prod',
     'clean'
   ]);
 
   grunt.registerTask('start-dev', [
-    'sync',
+    'copy',
     'webpack:dev',
     'clean',
     'concurrent:dev'

--- a/package.json
+++ b/package.json
@@ -124,11 +124,11 @@
     "grunt-cli": "1.2.0",
     "grunt-concurrent": "2.3.1",
     "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-eslint": "^19.0.0",
     "grunt-nodemon": "0.4.2",
     "grunt-sass": "^1.1.0",
-    "grunt-sync": "^0.6.2",
     "grunt-webpack": "^2.0.1",
     "jsdom": "^11.2.0",
     "jsdom-global": "^3.0.2",
@@ -180,4 +180,3 @@
     ]
   }
 }
-

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -30,7 +30,7 @@ const setupConfig = {
   tests: './paths/**/basicDivorce.js',
   output: process.cwd() + '/functional-output',
   helpers: {
-    WebDriverIO: {
+    WebDriver: {
       url: process.env.E2E_FRONTEND_URL || CONF.e2e.frontendUrl,
       browser,
       waitForTimeout,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3779,6 +3779,11 @@ file-loader@^0.8.1:
   dependencies:
     loader-utils "~0.2.5"
 
+file-sync-cmp@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz#a5e7a8ffbfa493b43b923bbd4ca89a53b63b612b"
+  integrity sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=
+
 file-type@^7.7.1:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-7.7.1.tgz#91c2f5edb8ce70688b9b68a90d931bbb6cb21f65"
@@ -4284,7 +4289,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -4450,6 +4455,14 @@ grunt-contrib-clean@^1.0.0:
     async "^1.5.2"
     rimraf "^2.5.1"
 
+grunt-contrib-copy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz#7060c6581e904b8ab0d00f076e0a8f6e3e7c3573"
+  integrity sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=
+  dependencies:
+    chalk "^1.1.1"
+    file-sync-cmp "^0.1.0"
+
 grunt-contrib-watch@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz#84a1a7a1d6abd26ed568413496c73133e990018f"
@@ -4519,16 +4532,6 @@ grunt-sass@^1.1.0:
     each-async "^1.0.0"
     node-sass "^3.7.0"
     object-assign "^4.0.1"
-
-grunt-sync@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/grunt-sync/-/grunt-sync-0.6.2.tgz#d9acb65b4205d017bd6462e49fec2d9071ace47b"
-  integrity sha1-2ay2W0IF0Be9ZGLkn+wtkHGs5Hs=
-  dependencies:
-    glob "^7.0.5"
-    lodash "^4.14.2"
-    md5-file "^2.0.3"
-    promised-io "0.3.5"
 
 grunt-webpack@^2.0.1:
   version "2.0.1"
@@ -6238,11 +6241,6 @@ math-expression-evaluator@^1.2.14:
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
   integrity sha1-3oGf282E3M2PrlnGrreWFbnSZqw=
 
-md5-file@^2.0.3:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-2.0.7.tgz#307f78bd04ccb054e467ec661cfa5a9afdc9f210"
-  integrity sha1-MH94vQTMsFTkZ+xmHPpamv3J8hA=
-
 md5-hex@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
@@ -7933,11 +7931,6 @@ promise-retry@^1.1.1:
   dependencies:
     err-code "^1.0.0"
     retry "^0.10.0"
-
-promised-io@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/promised-io/-/promised-io-0.3.5.tgz#4ad217bb3658bcaae9946b17a8668ecd851e1356"
-  integrity sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=
 
 prop-types@^15.5.8, prop-types@^15.6.2:
   version "15.7.2"


### PR DESCRIPTION
Locally starting and server and setting up assets was failing due to grunt-sync.
There is a deprecation notice for grunt-sync at https://www.npmjs.com/package/grunt-sync, with the note that it is similar to https://github.com/gruntjs/grunt-contrib-copy.
So this PR migrates the grunt-sync code over to grunt-contrib-copy instead.