### PR TITLE
DIV-4583 - fix incorrect step skipping on amend petition

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
         options: {
           nodeArgs: ['--trace-warnings', '--inspect'],
           ext: 'js, json, yaml',
-          ignore: ['node_modules/**', 'app/assets/**', 'public/**'],
+          ignore: ['node_modules/**', 'app/assets/**', 'public/**', 'functional-output/**', 'coverage/**', 'test/**'],
           args: grunt.option.flags()
         }
       }

--- a/app/core/helpers/steps.js
+++ b/app/core/helpers/steps.js
@@ -12,7 +12,7 @@ const getNextValidStep = function* (step, session) {
 
     // ensure step is valid
     const [isValid] = step.validate(nextStepCtx, session);
-    if (!step.isSkipWhenValid() && isValid) {
+    if (isValid) {
       nextStep = step.next(nextStepCtx, session);
     }
   } catch (error) {
@@ -27,6 +27,8 @@ const findNextUnAnsweredStep = function* (step, session = {}) {
 
   if (!nextStep) {
     return step;
+  } else if (!nextStep.isSkipWhenValid()) {
+    return nextStep;
   }
 
   return yield findNextUnAnsweredStep(nextStep, session);

--- a/app/core/helpers/steps.js
+++ b/app/core/helpers/steps.js
@@ -12,7 +12,7 @@ const getNextValidStep = function* (step, session) {
 
     // ensure step is valid
     const [isValid] = step.validate(nextStepCtx, session);
-    if (isValid) {
+    if (!step.isSkipWhenValid() && isValid) {
       nextStep = step.next(nextStepCtx, session);
     }
   } catch (error) {

--- a/app/core/helpers/steps.js
+++ b/app/core/helpers/steps.js
@@ -27,7 +27,7 @@ const findNextUnAnsweredStep = function* (step, session = {}) {
 
   if (!nextStep) {
     return step;
-  } else if (!nextStep.isSkipWhenValid()) {
+  } else if (!nextStep.shouldSkipWhenValid()) {
     return nextStep;
   }
 

--- a/app/core/helpers/steps.js
+++ b/app/core/helpers/steps.js
@@ -27,7 +27,7 @@ const findNextUnAnsweredStep = function* (step, session = {}) {
 
   if (!nextStep) {
     return step;
-  } else if (!nextStep.shouldSkipWhenValid()) {
+  } else if (!nextStep.isSkippable) {
     return nextStep;
   }
 

--- a/app/core/helpers/steps.test.js
+++ b/app/core/helpers/steps.test.js
@@ -57,7 +57,7 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub().returns([true]),
-        shouldSkipWhenValid: sinon.stub(),
+        isSkippable: sinon.stub(),
         next: sinon.stub()
       };
     });
@@ -66,7 +66,7 @@ describe(modulePath, () => {
       const nextStep2 = {
         name: 'test-step2',
         validate: sinon.stub().returns([true]),
-        shouldSkipWhenValid: sinon.stub()
+        isSkippable: sinon.stub()
       };
 
       const nextStep1 = {
@@ -74,7 +74,7 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub().returns([true]),
-        shouldSkipWhenValid: sinon.stub().returns(true),
+        isSkippable: sinon.stub().returns(true),
         next: sinon.stub().returns(nextStep2)
       };
 
@@ -91,13 +91,13 @@ describe(modulePath, () => {
       const nextStep2 = {
         name: 'test-step2',
         validate: sinon.stub().returns([true]),
-        shouldSkipWhenValid: sinon.stub()
+        isSkippable: sinon.stub()
       };
 
       const nextStep1 = {
         name: 'test-step1',
         validate: sinon.stub().returns([true]),
-        shouldSkipWhenValid: sinon.stub().returns(false),
+        isSkippable: sinon.stub().returns(false),
         next: sinon.stub().returns(nextStep2)
       };
 

--- a/app/core/helpers/steps.test.js
+++ b/app/core/helpers/steps.test.js
@@ -1,4 +1,5 @@
 const { expect, sinon } = require('test/util/chai');
+const { cloneDeep } = require('lodash');
 const co = require('co');
 
 const modulePath = 'app/core/helpers/steps';
@@ -15,28 +16,16 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub(),
-        isSkipWhenValid: sinon.stub(),
         next: sinon.stub().returns(aValidStep)
       };
     });
 
     it('returns a next step if valid', () => {
       testStep.validate.returns([true]);
-      testStep.isSkipWhenValid.returns(false);
 
       return co(function* generator() {
         const nextStep = yield steps.getNextValidStep(testStep, {});
         expect(nextStep).to.eql(aValidStep);
-      });
-    });
-
-    it('returns undefined if step is valid but skip is true', () => {
-      testStep.validate.returns([true]);
-      testStep.isSkipWhenValid.returns(true);
-
-      return co(function* generator() {
-        const nextStep = yield steps.getNextValidStep(testStep, {});
-        expect(nextStep).to.eql(undefined); // eslint-disable-line no-undefined
       });
     });
 
@@ -74,15 +63,36 @@ describe(modulePath, () => {
     });
 
     it('loops until no next step found', () => {
-      const stepShouldBeReturned = { name: 'nextStep' };
+      const stepShouldBeReturned1 = cloneDeep(testStep);
+      const stepShouldBeReturned2 = cloneDeep(testStep);
 
-      testStep.next.returns(stepShouldBeReturned);
-      testStep.isSkipWhenValid.returns(false);
+      testStep.next.returns(stepShouldBeReturned1);
+      stepShouldBeReturned1.next.returns(stepShouldBeReturned2);
+      stepShouldBeReturned2.next.returns(null);
+      stepShouldBeReturned1.isSkipWhenValid.returns(true);
+      stepShouldBeReturned2.isSkipWhenValid.returns(true);
 
       return co(function* generator() {
         const nextStep = yield steps.findNextUnAnsweredStep(testStep);
 
-        expect(nextStep).to.eql(stepShouldBeReturned);
+        expect(nextStep).to.eql(stepShouldBeReturned2);
+      });
+    });
+
+    it('returns next step if it should not be skipped', () => {
+      const stepShouldBeReturned1 = cloneDeep(testStep);
+      const stepShouldBeReturned2 = cloneDeep(testStep);
+
+      testStep.next.returns(stepShouldBeReturned1);
+      stepShouldBeReturned1.next.returns(stepShouldBeReturned2);
+      stepShouldBeReturned2.next.returns(null);
+      stepShouldBeReturned1.isSkipWhenValid.returns(false);
+      stepShouldBeReturned2.isSkipWhenValid.returns(true);
+
+      return co(function* generator() {
+        const nextStep = yield steps.findNextUnAnsweredStep(testStep);
+
+        expect(nextStep).to.eql(stepShouldBeReturned1);
       });
     });
   });

--- a/app/core/helpers/steps.test.js
+++ b/app/core/helpers/steps.test.js
@@ -15,16 +15,28 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub(),
+        isSkipWhenValid: sinon.stub(),
         next: sinon.stub().returns(aValidStep)
       };
     });
 
     it('returns a next step if valid', () => {
       testStep.validate.returns([true]);
+      testStep.isSkipWhenValid.returns(false);
 
       return co(function* generator() {
         const nextStep = yield steps.getNextValidStep(testStep, {});
         expect(nextStep).to.eql(aValidStep);
+      });
+    });
+
+    it('returns undefined if step is valid but skip is true', () => {
+      testStep.validate.returns([true]);
+      testStep.isSkipWhenValid.returns(true);
+
+      return co(function* generator() {
+        const nextStep = yield steps.getNextValidStep(testStep, {});
+        expect(nextStep).to.eql(undefined); // eslint-disable-line no-undefined
       });
     });
 
@@ -40,7 +52,7 @@ describe(modulePath, () => {
     it('returns undefined if error', () => {
       testStep.validate.returns([true]);
       testStep.next = () => {
-        throw new Error('Error occoured');
+        throw new Error('Error occurred');
       };
 
       return co(function* generator() {
@@ -56,6 +68,7 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub().returns([true]),
+        isSkipWhenValid: sinon.stub(),
         next: sinon.stub()
       };
     });
@@ -64,6 +77,7 @@ describe(modulePath, () => {
       const stepShouldBeReturned = { name: 'nextStep' };
 
       testStep.next.returns(stepShouldBeReturned);
+      testStep.isSkipWhenValid.returns(false);
 
       return co(function* generator() {
         const nextStep = yield steps.findNextUnAnsweredStep(testStep);

--- a/app/core/helpers/steps.test.js
+++ b/app/core/helpers/steps.test.js
@@ -57,7 +57,7 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub().returns([true]),
-        isSkippable: sinon.stub(),
+        isSkippable: true,
         next: sinon.stub()
       };
     });
@@ -66,7 +66,7 @@ describe(modulePath, () => {
       const nextStep2 = {
         name: 'test-step2',
         validate: sinon.stub().returns([true]),
-        isSkippable: sinon.stub()
+        isSkippable: true
       };
 
       const nextStep1 = {
@@ -74,7 +74,7 @@ describe(modulePath, () => {
         populateWithPreExistingData: sinon.stub().returns({}),
         interceptor: sinon.stub().returns({}),
         validate: sinon.stub().returns([true]),
-        isSkippable: sinon.stub().returns(true),
+        isSkippable: true,
         next: sinon.stub().returns(nextStep2)
       };
 
@@ -91,13 +91,13 @@ describe(modulePath, () => {
       const nextStep2 = {
         name: 'test-step2',
         validate: sinon.stub().returns([true]),
-        isSkippable: sinon.stub()
+        isSkippable: true
       };
 
       const nextStep1 = {
         name: 'test-step1',
         validate: sinon.stub().returns([true]),
-        isSkippable: sinon.stub().returns(false),
+        isSkippable: false,
         next: sinon.stub().returns(nextStep2)
       };
 

--- a/app/core/steps/Step.js
+++ b/app/core/steps/Step.js
@@ -89,7 +89,7 @@ module.exports = class Step {
     return [true, []];
   }
 
-  shouldSkipWhenValid() {
+  get isSkippable() {
     return true;
   }
 

--- a/app/core/steps/Step.js
+++ b/app/core/steps/Step.js
@@ -90,7 +90,7 @@ module.exports = class Step {
   }
 
   isSkipWhenValid() {
-    return false;
+    return true;
   }
 
   generateContent(ctx, session, lang = 'en') {

--- a/app/core/steps/Step.js
+++ b/app/core/steps/Step.js
@@ -89,6 +89,10 @@ module.exports = class Step {
     return [true, []];
   }
 
+  isSkipWhenValid() {
+    return false;
+  }
+
   generateContent(ctx, session, lang = 'en') {
     if (!this.content || !this.content.resources) {
       throw new ReferenceError(`Step ${this.name} has no content.json in it's resource folder`);

--- a/app/core/steps/Step.js
+++ b/app/core/steps/Step.js
@@ -89,7 +89,7 @@ module.exports = class Step {
     return [true, []];
   }
 
-  isSkipWhenValid() {
+  shouldSkipWhenValid() {
     return true;
   }
 

--- a/app/core/steps/Step.test.js
+++ b/app/core/steps/Step.test.js
@@ -104,8 +104,8 @@ describe(modulePath, () => {
       expect(step.action('ctx', 'session')).to.eql(['ctx', 'session']);
     });
 
-    it('#isSkipWhenValid is true by default', () => {
-      expect(step.isSkipWhenValid())
+    it('#shouldSkipWhenValid is true by default', () => {
+      expect(step.shouldSkipWhenValid())
         .to.equal(true);
     });
   });

--- a/app/core/steps/Step.test.js
+++ b/app/core/steps/Step.test.js
@@ -104,9 +104,9 @@ describe(modulePath, () => {
       expect(step.action('ctx', 'session')).to.eql(['ctx', 'session']);
     });
 
-    it('#isSkipWhenValid is false by default', () => {
+    it('#isSkipWhenValid is true by default', () => {
       expect(step.isSkipWhenValid())
-        .to.equal(false);
+        .to.equal(true);
     });
   });
 

--- a/app/core/steps/Step.test.js
+++ b/app/core/steps/Step.test.js
@@ -104,8 +104,8 @@ describe(modulePath, () => {
       expect(step.action('ctx', 'session')).to.eql(['ctx', 'session']);
     });
 
-    it('#shouldSkipWhenValid is true by default', () => {
-      expect(step.shouldSkipWhenValid())
+    it('#isSkippable is true by default', () => {
+      expect(step.isSkippable)
         .to.equal(true);
     });
   });

--- a/app/core/steps/Step.test.js
+++ b/app/core/steps/Step.test.js
@@ -103,6 +103,11 @@ describe(modulePath, () => {
     it('#action returns two arguments as an array', () => {
       expect(step.action('ctx', 'session')).to.eql(['ctx', 'session']);
     });
+
+    it('#isSkipWhenValid is false by default', () => {
+      expect(step.isSkipWhenValid())
+        .to.equal(false);
+    });
   });
 
   describe('#generateContent()', () => {

--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -306,6 +306,6 @@ module.exports = class CheckYourAnswers extends ValidationStep {
   }
 
   isSkipWhenValid() {
-    return true;
+    return false;
   }
 };

--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -305,7 +305,7 @@ module.exports = class CheckYourAnswers extends ValidationStep {
       });
   }
 
-  shouldSkipWhenValid() {
+  get isSkippable() {
     return false;
   }
 };

--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -304,4 +304,8 @@ module.exports = class CheckYourAnswers extends ValidationStep {
         res.redirect('/generic-error');
       });
   }
+
+  isSkipWhenValid() {
+    return true;
+  }
 };

--- a/app/steps/check-your-answers/index.js
+++ b/app/steps/check-your-answers/index.js
@@ -305,7 +305,7 @@ module.exports = class CheckYourAnswers extends ValidationStep {
       });
   }
 
-  isSkipWhenValid() {
+  shouldSkipWhenValid() {
     return false;
   }
 };

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -1003,9 +1003,9 @@ describe(modulePath, () => {
     });
   });
 
-  describe('#isSkipWhenValid', () => {
+  describe('#shouldSkipWhenValid', () => {
     it('Ensure we visit the check-your-answers page even if a statement of truth was saved to the draft', done => {
-      expect(underTest.isSkipWhenValid()).to.equal(false);
+      expect(underTest.shouldSkipWhenValid()).to.equal(false);
       done();
     });
   });

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -1004,8 +1004,9 @@ describe(modulePath, () => {
   });
 
   describe('#isSkipWhenValid', () => {
-    it('Ensure we visit the check-your-answers page even if a statement of truth was saved to the draft', () => {
-      expect(underTest.isSkipWhenValid()).to.equal(true);
+    it('Ensure we visit the check-your-answers page even if a statement of truth was saved to the draft', done => {
+      expect(underTest.isSkipWhenValid()).to.equal(false);
+      done();
     });
   });
 });

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -1003,9 +1003,9 @@ describe(modulePath, () => {
     });
   });
 
-  describe('#shouldSkipWhenValid', () => {
+  describe('#isSkippable', () => {
     it('Ensure we visit the check-your-answers page even if a statement of truth was saved to the draft', done => {
-      expect(underTest.shouldSkipWhenValid()).to.equal(false);
+      expect(underTest.isSkippable).to.equal(false);
       done();
     });
   });

--- a/app/steps/check-your-answers/index.test.js
+++ b/app/steps/check-your-answers/index.test.js
@@ -153,7 +153,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('help with fees refference number does not exists warning', () => {
+  describe('help with fees reference number does not exists warning', () => {
     beforeEach(done => {
       session = clone(mockSession);
       delete session.helpWithFeesReferenceNumber;
@@ -167,7 +167,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('help with fees refference number does not exists payment', () => {
+  describe('help with fees reference number does not exists payment', () => {
     beforeEach(done => {
       session = clone(mockSession);
       delete session.helpWithFeesReferenceNumber;
@@ -1000,6 +1000,12 @@ describe(modulePath, () => {
           .to.equal(s.steps.ApplicationSubmitted.url);
       },
       'post', true, postBody);
+    });
+  });
+
+  describe('#isSkipWhenValid', () => {
+    it('Ensure we visit the check-your-answers page even if a statement of truth was saved to the draft', () => {
+      expect(underTest.isSkipWhenValid()).to.equal(true);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:smoke": "./bin/run-smoke-tests.sh",
     "test:functional": "./bin/run-functional-tests.sh",
     "test:crossbrowser": "./bin/run-crossbrowser-tests.sh",
-    "test-unit": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. mocha './app/**/*.test.js' --reporter spec --recursive -t 3000",
+    "test-unit": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. mocha './app/**/*.test.js' --reporter spec --recursive -t 10000",
     "test-unit-ide": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. mocha $NODE_DEBUG_OPTION './app/**/*.test.js' --reporter spec --recursive",
     "test-validation": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. mocha test/validation/ --reporter spec --recursive --timeout 15000",
     "test-e2e": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. ./node_modules/.bin/codeceptjs run-multiple parallel -c test/end-to-end/codecept.conf.js --steps --reporter mocha-multi",

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -75,7 +75,7 @@ function configureChunks() {
 function getTests() {
   console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
   if (CONF.preview_env === 'true') {
-    return './paths/**/basicDivorce.js';
+    return './paths/**/*.js';
   } else {
     return './paths/**/*.js';
   }

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -75,7 +75,7 @@ function configureChunks() {
 function getTests() {
   console.log('### CONF.preview_env =', CONF.preview_env);  // eslint-disable-line no-console
   if (CONF.preview_env === 'true') {
-    return './paths/**/*.js';
+    return './paths/**/basicDivorce.js';
   } else {
     return './paths/**/*.js';
   }

--- a/test/end-to-end/data/amendPetitionSessionWithConfirmation.js
+++ b/test/end-to-end/data/amendPetitionSessionWithConfirmation.js
@@ -1,0 +1,2 @@
+const baseAmendSession = require('./amendPetitionSession');
+module.exports = Object.assign(baseAmendSession, { 'confirmPrayer': 'Yes' });

--- a/test/end-to-end/helpers/SessionHelper.js
+++ b/test/end-to-end/helpers/SessionHelper.js
@@ -2,12 +2,14 @@ const unirest = require('unirest');
 const { assert } = require('chai');
 const basicDivorceSessionData = require('test/end-to-end/data/basicDivorceSessionData');
 const amendPetitionSession = require('test/end-to-end/data/amendPetitionSession');
+const amendPetitionSessionWithConfirmation = require('test/end-to-end/data/amendPetitionSessionWithConfirmation');
 const Tokens = require('csrf');
 const CONF = require('config');
 const logger = require('app/services/logger').logger(__filename);
 const availableSessions = {
   basicDivorceSessionData,
-  amendPetitionSession
+  amendPetitionSession,
+  amendPetitionSessionWithConfirmation
 };
 
 class SessionHelper extends codecept_helper {

--- a/test/end-to-end/pages/index/index.js
+++ b/test/end-to-end/pages/index/index.js
@@ -16,22 +16,13 @@ function startApplication(ignoreIdamToggle = false) {
   }
 }
 
-async function startApplicationWithAnExistingSession() {
+async function startApplicationWith(sessionName) {
 
   let I = this;
 
   I.amOnLoadedPage('/index');
   I.startApplication();
-  I.haveABasicSession('basicDivorceSessionData');
-}
-
-async function startApplicationWithAnAmendPetitionSession() {
-
-  let I = this;
-
-  I.amOnLoadedPage('/index');
-  I.startApplication();
-  I.haveABasicSession('amendPetitionSession');
+  I.haveABasicSession(sessionName);
 }
 
 function* seeCookieBanner() {
@@ -73,8 +64,7 @@ function signOut() {
 
 module.exports = {
   startApplication,
-  startApplicationWithAnExistingSession,
-  startApplicationWithAnAmendPetitionSession,
+  startApplicationWith,
   seeCookieBanner,
   seeCookieFooter,
   followCookieBannerLink,

--- a/test/end-to-end/paths/amend.js
+++ b/test/end-to-end/paths/amend.js
@@ -1,0 +1,8 @@
+Feature('Amend petition');
+
+Scenario('Submit an amend petition with an existing statement of truth stops at Check Your Answers', async function(I) {
+  I.startApplicationWith('amendPetitionSessionWithConfirmation');
+  I.amOnLoadedPage('/index');
+  I.click('Continue');
+  I.seeCurrentUrlEquals('/check-your-answers');
+});

--- a/test/end-to-end/paths/payment.js
+++ b/test/end-to-end/paths/payment.js
@@ -13,7 +13,7 @@ Scenario('Fee displays on /pay/help/need-help page', function (I) {
 });
 
 Scenario('Card payment online', function* (I) {
-  I.startApplicationWithAnExistingSession();
+  I.startApplicationWith('basicDivorceSessionData');
   I.amOnLoadedPage('/pay/help/need-help');
   I.selectHelpWithFees(false);
   I.amOnLoadedPage('/check-your-answers');
@@ -27,7 +27,7 @@ Scenario('Card payment online', function* (I) {
 
 
 Scenario('Card payment online failure', function* (I) {
-  I.startApplicationWithAnExistingSession();
+  I.startApplicationWith('basicDivorceSessionData');
   I.amOnLoadedPage('/pay/help/need-help');
   I.selectHelpWithFees(false);
   I.amOnLoadedPage('/check-your-answers');
@@ -46,7 +46,7 @@ Scenario('Card payment online failure', function* (I) {
 });
 
 Scenario('Card payment online cancellation with retry', function* (I) {
-  I.startApplicationWithAnExistingSession();
+  I.startApplicationWith('basicDivorceSessionData');
   I.amOnLoadedPage('/pay/help/need-help');
   I.selectHelpWithFees(false);
   I.amOnLoadedPage('/check-your-answers');

--- a/test/end-to-end/paths/save-resume.js
+++ b/test/end-to-end/paths/save-resume.js
@@ -122,7 +122,7 @@ Scenario('I delete my amend petition from draft store', function (I) {
     I.seeCookie('mockRestoreSession');
   }
 
-  I.startApplicationWithAnAmendPetitionSession();
+  I.startApplicationWith('amendPetitionSession');
   I.checkMyAnswersRemoveApplication();
   I.confirmRemoveApplication();
   I.seeCurrentUrlEquals('/exit/removed-saved-application');
@@ -145,7 +145,7 @@ Scenario('I do not delete my amend petition from draft store', function (I) {
     I.seeCookie('mockRestoreSession');
   }
 
-  I.startApplicationWithAnAmendPetitionSession();
+  I.startApplicationWith('amendPetitionSession');
   I.checkMyAnswersRemoveApplication();
   I.declineRemoveApplicaiton();
 


### PR DESCRIPTION


# Description

This is to fix a scenario where skipping answered questions still stops
at Check Your Answers, because the user could have answered a question,
then clicked saved an resume, which means they come back, the page is
skipped and the case is not submitted

Fixes #DIV-4583

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
