### PR TITLE
fix error where session is being destroyed

### DIFF
--- a/app/steps/authenticated/index.js
+++ b/app/steps/authenticated/index.js
@@ -11,7 +11,7 @@ const runNext = (req, res, next) => {
   // if the previous session has expired
   // after user logged in then destroy it
   if (session.expires <= Date.now()) {
-    req.session.destroy(() => {
+    req.session.regenerate(() => {
       next();
     });
   } else {

--- a/app/steps/authenticated/index.test.js
+++ b/app/steps/authenticated/index.test.js
@@ -82,7 +82,7 @@ describe(modulePath, () => {
         withSession(done, agent, session);
       });
 
-      it('ensure session data is destroyed if expired after user login', done => {
+      it('ensure session data is regenerated if expired after user login', done => {
         expect(session.hasOwnProperty('courts')).to.eql(true);
 
         const testSession = () => {

--- a/app/steps/authenticated/index.test.js
+++ b/app/steps/authenticated/index.test.js
@@ -89,6 +89,7 @@ describe(modulePath, () => {
           getSession(agent)
             .then(newSession => {
               expect(newSession.hasOwnProperty('courts')).to.eql(false);
+              expect(newSession.hasOwnProperty('expires')).to.eql(true);
             })
             .then(done, done);
         };


### PR DESCRIPTION
# Description

[DIV-4366 - Amend petition : When we move from DN to PFE - internal server error- intermittent](https://tools.hmcts.net/jira/browse/DIV-4366)
 - Fix bug where 500 error being returned to the user due to session being destroyed without being regenerated 