### PR TITLE
DIV-4591: Changing the way we check whether the client's browser accepts cookies

### DIFF
--- a/app/middleware/checkCookiesAllowed.js
+++ b/app/middleware/checkCookiesAllowed.js
@@ -1,11 +1,25 @@
-function checkCookiesAllowed(req, res, next) {
-  const requiredCookiesAreSet = req.cookies['connect.sid'];
+const attemptToSetTestCookieParam = 'attemptToSetTestCookie';
+const testCookieName = 'test';
 
-  if (requiredCookiesAreSet) {
+function checkCookiesAllowed(req, res, next) {
+  const cookies = req.cookies;
+
+  if (Object.keys(cookies).length) {
+    // Remove test cookie, if it exists
+    res.clearCookie('test');
+
     next();
+  } else if (req.query[attemptToSetTestCookieParam]) {
+    // This is an attempt to set a test cookie
+
+    if (!cookies.test) {
+      // Client does not accept cookies. Show them error page
+      res.redirect('/cookie-error');
+    }
   } else {
-    //  cookie could not be set
-    res.redirect('/cookie-error');
+    // Cookie was not found, we'll attempt to set a test cookie
+    res.cookie(testCookieName, 'testCookie');
+    res.redirect(`${req.baseUrl}?${attemptToSetTestCookieParam}=true`);
   }
 }
 

--- a/app/middleware/checkCookiesAllowed.test.js
+++ b/app/middleware/checkCookiesAllowed.test.js
@@ -7,37 +7,46 @@ let req = {};
 let res = {};
 let next = {};
 
+const queryStringParameter = 'attemptToSetTestCookie';
+
 describe(modulePath, () => {
   beforeEach(() => {
     req = {
       session: {},
       originalUrl: '/page',
-      cookies: {}
+      cookies: {},
+      baseUrl: '/originatingPage',
+      query: {}
     };
 
-    res = { redirect: sinon.stub() };
+    res = {
+      redirect: sinon.stub(),
+      cookie: sinon.stub(),
+      clearCookie: sinon.stub()
+    };
 
     next = sinon.stub();
   });
 
   describe('cookies allowed and exist', () => {
     beforeEach(() => {
-      req.cookies['connect.sid'] = 'exists';
-
+      req.cookies.someOtherCookie = 'someOtherCookieValue';
       underTest(req, res, next);
     });
 
     it('should call next', () => {
       expect(next.callCount).to.equal(1);
+      expect(res.clearCookie.calledWith('test')).to.equal(true);
     });
 
-    it('should not redirect', () => {
+    it('should not redirect to error page', () => {
       expect(res.redirect.calledWith('/cookie-error')).to.not.equal(true);
     });
   });
 
   describe('cookies missing', () => {
     beforeEach(() => {
+      req.cookies = {};
       underTest(req, res, next);
     });
 
@@ -45,7 +54,24 @@ describe(modulePath, () => {
       expect(next.callCount).to.equal(0);
     });
 
-    it('should redirect', () => {
+    it('should set test cookie and redirect to the same page with querystring parameter', () => {
+      expect(res.cookie.calledWith('test', 'testCookie')).to.equal(true);
+      expect(res.redirect.calledWith(`/originatingPage?${queryStringParameter}=true`)).to.equal(true);
+    });
+  });
+
+  describe('cookies missing and test cookie could not be set', () => {
+    beforeEach(() => {
+      req.cookies = {};
+      req.query[queryStringParameter] = true;
+      underTest(req, res, next);
+    });
+
+    it('should not call next', () => {
+      expect(next.callCount).to.equal(0);
+    });
+
+    it('should redirect to error page', () => {
       expect(res.redirect.calledWith('/cookie-error')).to.equal(true);
     });
   });


### PR DESCRIPTION
# Description

Changing the way we check whether the client's browser accepts cookies. The old way was checking for a specific cookie that was only set when a session was created. That caused problems if a user was redirected from the DN having no PFE cookies created for them.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
