### PR TITLE
Remove default postMiddleware in delete draft scenario

### DIFF
--- a/app/steps/save-resume/confirm-remove-saved-application/index.js
+++ b/app/steps/save-resume/confirm-remove-saved-application/index.js
@@ -31,7 +31,7 @@ module.exports = class DeleteApplication extends ValidationStep {
   get checkYourAnswersTemplate() {
     return false;
   }
-  
+
   // don't call default save draft middleware
   get postMiddleware() {
     return [];

--- a/app/steps/save-resume/confirm-remove-saved-application/index.js
+++ b/app/steps/save-resume/confirm-remove-saved-application/index.js
@@ -31,4 +31,9 @@ module.exports = class DeleteApplication extends ValidationStep {
   get checkYourAnswersTemplate() {
     return false;
   }
+  
+  // don't call default save draft middleware
+  get postMiddleware() {
+    return [];
+  }
 };

--- a/app/steps/save-resume/confirm-remove-saved-application/index.test.js
+++ b/app/steps/save-resume/confirm-remove-saved-application/index.test.js
@@ -20,6 +20,10 @@ describe(modulePath, () => {
   });
 
   describe('success', () => {
+    it('does not have a postMiddleware', () => {
+      expect(underTest.postMiddleware).to.eql([]);
+    });
+
     it('renders the content from the content file', done => {
       testContent(done, agent, underTest, content);
     });


### PR DESCRIPTION
# Description

Sometimes the draft was not getting deleted after going to the delete draft page.
Actually, the draft was getting deleted, but there was a race condition with the saveDraft postMiddleware on the confirm delete draft page. Most of the time, the saveDraft middleware resolves first, but rarely the deleteDraft middleware will resolve first and the saveDraft one happens immediately after.

This fix removes the postMiddleware from being called by the confirm delete page, as there is no reason to save the answer to 'Do you want to delete your draft'.

Maybe a discussion to see if we can enforce request orders may be required, i.e. resolve all promises before triggering the res.redirect on a POST request.

Fixes # (issue)

https://tools.hmcts.net/jira/browse/DIV-4509

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
