### PR TITLE
Update sonar-scanner module version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ package-lock.json
 functional-output
 .stryker-tmp
 local*.yaml
+.scannerwork/

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "sinon": "^2.3.4",
     "sinon-chai": "^2.8.0",
     "sinon-stub-promise": "^4.0.0",
-    "sonar-scanner": "^1.0.1",
+    "sonar-scanner": "^3.1.0",
     "stryker-api": "^0.16.0",
     "stryker-html-reporter": "^0.13.2",
     "stryker-javascript-mutator": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9081,10 +9081,10 @@ socks@^1.1.10:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
-sonar-scanner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sonar-scanner/-/sonar-scanner-1.0.1.tgz#09ec309e30e5e9570a4ccaf21dcc1adc2b1856c5"
-  integrity sha1-CewwnjDl6VcKTMryHcwa3CsYVsU=
+sonar-scanner@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/sonar-scanner/-/sonar-scanner-3.1.0.tgz#51c1c1101f54b98abc5d8565209b1d9232979343"
+  integrity sha1-UcHBEB9UuYq8XYVlIJsdkjKXk0M=
 
 sort-keys@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Was using a very old version of sonar-scan. Updating to the latest 3.1.0 which both RFE and DN use.