### PR TITLE
Use hardcoded day value so differing month days don't throw an error

### DIFF
--- a/app/steps/marriage/date/index.test.js
+++ b/app/steps/marriage/date/index.test.js
@@ -13,6 +13,7 @@ const modulePath = 'app/steps/marriage/date';
 
 const content = require(`${modulePath}/content`);
 
+const FIRST_DAY_OF_MONTH = 1;
 const ONE_HUNDRED_YEARS = 100;
 const TEN_MONTHS = 10;
 
@@ -93,7 +94,7 @@ describe(modulePath, () => {
       const marriageDateInFuture = moment().add(1, 'years');
 
       const context = {
-        marriageDateDay: marriageDateInFuture.date(),
+        marriageDateDay: FIRST_DAY_OF_MONTH,
         marriageDateMonth: marriageDateInFuture.month() + 1,
         marriageDateYear: marriageDateInFuture.year()
       };
@@ -105,7 +106,7 @@ describe(modulePath, () => {
       const marriageDateOld = moment().subtract(ONE_HUNDRED_YEARS, 'years');
 
       const context = {
-        marriageDateDay: marriageDateOld.date(),
+        marriageDateDay: FIRST_DAY_OF_MONTH,
         marriageDateMonth: marriageDateOld.month() - 1,
         marriageDateYear: marriageDateOld.year()
       };
@@ -117,7 +118,7 @@ describe(modulePath, () => {
       const marriageDate1YearAgo = moment().subtract(TEN_MONTHS, 'months');
 
       const context = {
-        marriageDateDay: marriageDate1YearAgo.date(),
+        marriageDateDay: FIRST_DAY_OF_MONTH,
         marriageDateMonth: marriageDate1YearAgo.format('MM'),
         marriageDateYear: marriageDate1YearAgo.year()
       };

--- a/app/steps/marriage/date/index.test.js
+++ b/app/steps/marriage/date/index.test.js
@@ -13,8 +13,8 @@ const modulePath = 'app/steps/marriage/date';
 
 const content = require(`${modulePath}/content`);
 
-const FIRST_DAY_OF_MONTH = 1;
-const ONE_HUNDRED_YEARS = 100;
+const FIRST = 1;
+const ONE_HUNDRED_ONE_YEARS = 101;
 const TEN_MONTHS = 10;
 
 let s = {};
@@ -94,7 +94,7 @@ describe(modulePath, () => {
       const marriageDateInFuture = moment().add(1, 'years');
 
       const context = {
-        marriageDateDay: FIRST_DAY_OF_MONTH,
+        marriageDateDay: FIRST,
         marriageDateMonth: marriageDateInFuture.month() + 1,
         marriageDateYear: marriageDateInFuture.year()
       };
@@ -103,11 +103,11 @@ describe(modulePath, () => {
     });
 
     it('renders error for "more than 100 years in the past"', done => {
-      const marriageDateOld = moment().subtract(ONE_HUNDRED_YEARS, 'years');
+      const marriageDateOld = moment().subtract(ONE_HUNDRED_ONE_YEARS, 'years');
 
       const context = {
-        marriageDateDay: FIRST_DAY_OF_MONTH,
-        marriageDateMonth: marriageDateOld.month() - 1,
+        marriageDateDay: FIRST,
+        marriageDateMonth: FIRST,
         marriageDateYear: marriageDateOld.year()
       };
 
@@ -118,7 +118,7 @@ describe(modulePath, () => {
       const marriageDate1YearAgo = moment().subtract(TEN_MONTHS, 'months');
 
       const context = {
-        marriageDateDay: FIRST_DAY_OF_MONTH,
+        marriageDateDay: FIRST,
         marriageDateMonth: marriageDate1YearAgo.format('MM'),
         marriageDateYear: marriageDate1YearAgo.year()
       };


### PR DESCRIPTION
Basically, today's date is 29/04/2019

The failing test does:
Years - 100
Month - 1
Day - Same

However, on today's date, this results in the following date:
29/02/1919 (because month is 0 indexed, i.e. January is 00, so April is 03, so -1 results in 2, which when used in the citizen UI context relates to February)

Being a non-leap year day, 29 is not a valid date, resulting in the Invalid Date error showing instead of 100 years in the past.

This PR tries to resolve for that scenario by forcing the day component to be 1.