### PR TITLE
Change layout for Addresses on CYA

### DIFF
--- a/app/steps/living-arrangements/last-lived-together/at-petitioner-home-address/partials/checkYourAnswersTemplate.html
+++ b/app/steps/living-arrangements/last-lived-together/at-petitioner-home-address/partials/checkYourAnswersTemplate.html
@@ -1,10 +1,12 @@
 <tr>
   <th>
     {{ content.question | safe }}
+  </th>
+  <td>
+    {{ fields.livingArrangementsLastLivedTogether.value }}
     {% if session.petitionerHomeAddress %}
       <span class="address">{{ session.petitionerHomeAddress.address | join("<br/>") | safe }}</span>
     {% endif %}
-  </th>
-  <td>{{ fields.livingArrangementsLastLivedTogether.value }}</td>
+  </td>
   <td><a class="link" aria-label="{{ content.change }} {{ content.question | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>
 </tr>

--- a/app/steps/petitioner/correspondence/use-home-address/partials/checkYourAnswersTemplate.html
+++ b/app/steps/petitioner/correspondence/use-home-address/partials/checkYourAnswersTemplate.html
@@ -1,10 +1,12 @@
 <tr>
   <th>
     {{ content.question | safe }}
+  </th>
+  <td>
+    {{ fields.petitionerCorrespondenceUseHomeAddress.value }}
     {% if session.petitionerHomeAddress %}
       <span class="address">{{ session.petitionerHomeAddress.address.join('<br/>') | safe }}</span>
     {% endif %}
-  </th>
-  <td>{{ fields.petitionerCorrespondenceUseHomeAddress.value }}</td>
+  </td>
   <td><a class="link" aria-label="{{ content.change }} {{ content.question | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>
 </tr>

--- a/app/steps/respondent/correspondence/use-home-address/partials/checkYourAnswersTemplate.html
+++ b/app/steps/respondent/correspondence/use-home-address/partials/checkYourAnswersTemplate.html
@@ -1,9 +1,6 @@
 <tr>
   <th>
     {{ content.question | safe }}
-    {% if fields.respondentCorrespondenceDisplayAddress.value %}
-      <span class="address">{{ fields.respondentCorrespondenceDisplayAddress.value.address | join("<br/>") | safe }}</span>
-    {% endif %}
   </th>
   <td>
     {% if fields.respondentCorrespondenceUseHomeAddress.value === 'Yes' %}
@@ -12,6 +9,9 @@
       {{ content.no | safe }}
     {% elseif fields.respondentCorrespondenceUseHomeAddress.value === 'Solicitor' %}
       {{ content.solicitor | safe }}
+    {% endif %}
+    {% if fields.respondentCorrespondenceDisplayAddress.value %}
+      <span class="address">{{ fields.respondentCorrespondenceDisplayAddress.value.address | join("<br/>") | safe }}</span>
     {% endif %}
   </td>
   <td><a class="link" aria-label="{{ content.change }} {{ content.question | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>

--- a/app/steps/respondent/home/lives-at-last-address/partials/checkYourAnswersTemplate.html
+++ b/app/steps/respondent/home/lives-at-last-address/partials/checkYourAnswersTemplate.html
@@ -1,9 +1,6 @@
 <tr>
   <th>
     {{ content.question | safe }}<br/>
-    {% if fields.livingArrangementsLastLivedTogetherAddress.value %}
-      <span class="address">{{ fields.livingArrangementsLastLivedTogetherAddress.value.address | join("<br/>") | safe }}</span>
-    {% endif %}
   </th>
   <td>
     {% if fields.respondentLivesAtLastAddress.value === 'Yes' %}
@@ -12,6 +9,9 @@
       {{ content.no | safe }}
     {% elseif fields.respondentLivesAtLastAddress.value === 'Unknown' %}
       {{ content.unknown | safe }}
+    {% endif %}
+    {% if fields.livingArrangementsLastLivedTogetherAddress.value %}
+      <span class="address">{{ fields.livingArrangementsLastLivedTogetherAddress.value.address | join("<br/>") | safe }}</span>
     {% endif %}
   </td>
   <td><a class="link" aria-label="{{ content.change }} {{ content.question | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>


### PR DESCRIPTION
# Description

[DIV-4738](https://tools.hmcts.net/jira/browse/DIV-4738)

This PR moves the display of addresses on the Check Your Answers page to the centre column.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
