### PR TITLE
DIV-4860 - removed unnecessary sandbox stubbing

### DIFF
--- a/app/middleware/draftPetitionStoreMiddleware.test.js
+++ b/app/middleware/draftPetitionStoreMiddleware.test.js
@@ -160,19 +160,15 @@ describe(modulePath, () => {
       req = { query: {} };
       next = sinon.stub();
       sinon.stub(stepsHelper, 'findNextUnAnsweredStep').resolves(s.steps.WithFees);
+      sinon.stub(mockedClient, 'saveToDraftStore').resolves();
     });
 
     afterEach(() => {
       stepsHelper.findNextUnAnsweredStep.restore();
+      mockedClient.saveToDraftStore.restore();
     });
 
     it('redirects to next ExitApplicationSaved when user saves and exits', done => {
-      const sandbox = sinon.sandbox.create();
-
-      sandbox
-        .stub(mockedClient, 'saveToDraftStore')
-        .resolves();
-
       req = {
         originalUrl: '/not-with-fees-url',
         session: { previousCaseId: '1234' },


### PR DESCRIPTION
# Description

A new test was introduced as part of #541, which was somehow causing a memory leak in tests

```
[Unit tests and Sonar scan] FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
[Unit tests and Sonar scan]  1: node::Abort() [/usr/bin/node]
[Unit tests and Sonar scan]  2: 0x8ccf9c [/usr/bin/node]
[Unit tests and Sonar scan]  3: v8::Utils::ReportOOMFailure(char const*, bool) [/usr/bin/node]
[Unit tests and Sonar scan]  4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [/usr/bin/node]
```

Fixes #DIV-4860

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
