### PR TITLE
DIV-5103 - Update email address for divorce cases

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -394,7 +394,7 @@ variable "court_service_centre_openinghours" {
 }
 
 variable "court_service_centre_email" {
-  default = "contactdivorce@justice.gov.uk"
+  default = "divorcecase@justice.gov.uk"
 }
 
 variable "court_service_centre_phonenumber" {


### PR DESCRIPTION
# Description

[DIV-5103 - Update email address for divorce cases](https://tools.hmcts.net/jira/browse/DIV-5103)
 - change contactdivorce@justice.gov.uk to divorcecase@justice.gov.uk