### PR TITLE
DIV-5103 - Update email address for divorce cases

### DIFF
--- a/charts/div-pfe/values.yaml
+++ b/charts/div-pfe/values.yaml
@@ -23,7 +23,7 @@ nodejs:
         COURT_SERVICE_CENTRE_CITY: "Nottingham"
         COURT_SERVICE_CENTRE_POBOX: "PO Box 10447"
         COURT_SERVICE_CENTRE_POSTCODE: "NG2 9QN"
-        COURT_SERVICE_CENTRE_EMAIL: "contactdivorce@justice.gov.uk"
+        COURT_SERVICE_CENTRE_EMAIL: "divorcecase@justice.gov.uk"
         COURT_SERVICE_CENTRE_OPENINGHOURS: "Telephone Enquiries from: 8.30am to 5pm"
         COURT_SERVICE_CENTRE_PHONENUMBER: "0300 303 0642"
         COURT_SERVICE_CENTRE_SITEID: "CTSC"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -394,7 +394,7 @@ variable "court_service_centre_openinghours" {
 }
 
 variable "court_service_centre_email" {
-  default = "contactdivorce@justice.gov.uk"
+  default = "divorcecase@justice.gov.uk"
 }
 
 variable "court_service_centre_phonenumber" {

--- a/test/end-to-end/data/amendPetitionSession.js
+++ b/test/end-to-end/data/amendPetitionSession.js
@@ -126,7 +126,7 @@ module.exports = {
       'poBox': 'PO Box 10447',
       'postCode': 'NG2 9QN',
       'openingHours': 'Telephone Enquiries from: 8.30am to 5pm',
-      'email': 'contactdivorce@justice.gov.uk',
+      'email': 'divorcecase@justice.gov.uk',
       'phoneNumber': '0300 303 0642',
       'siteId': 'AA01'
     }


### PR DESCRIPTION
# Description

[DIV-5103 - Update email address for divorce cases](https://tools.hmcts.net/jira/browse/DIV-5103)
 - change contactdivorce@justice.gov.uk to divorcecase@justice.gov.uk