### PR TITLE
Update to use the public HMCTS docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmcts.azurecr.io/hmcts/base/node/stretch-slim-lts-8:latest as base
+FROM hmctspublic.azurecr.io/base/node/stretch-slim-lts-8:8-stretch-slim as base
 USER root
 RUN apt-get update && apt-get install -y bzip2 git python2.7 python-pip
 COPY package.json yarn.lock ./


### PR DESCRIPTION
# Description

> Next monday we will be changing the registry the pipeline will be pushing to by default
> the registry will be changing from:
> hmcts => hmctspublic
> you will no longer need to log in to pull your images (because it is a public registry, same as dockerhub)
> the name of the "repo" will change from
> "hmcts/product-component" => "product/component"


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
