### PR TITLE
Cross-Browser - Mobile - No Padding on postcode lookup

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -157,6 +157,7 @@ a.link-sign-out {
   width: 8.5em;
   @include govuk-media-query($from: mobile) {
     width: 100%;
+    margin-bottom: govuk-spacing(2)
   }
 }
 


### PR DESCRIPTION
# Description

[DIV-883 Cross-Browser - Mobile - No Padding on postcode lookup](https://tools.hmcts.net/jira/browse/DIV-883)
 - added margin to postcode field when on mobile device