### PR TITLE
Use div-pay-client 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@hmcts/div-idam-express-middleware": "^6.5.0",
-    "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#6.2.1",
+    "@hmcts/div-pay-client": "https://github.com/hmcts/div-pay-client#7.0.0",
     "@hmcts/div-service-auth-provider-client": "https://github.com/hmcts/div-service-auth-provider-client#3.0.0",
     "@hmcts/nodejs-healthcheck": "^1.5.1",
     "@hmcts/nodejs-logging": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,11 +147,12 @@
     request-promise-native "^1.0.7"
     socks5-https-client "^1.2.1"
 
-"@hmcts/div-pay-client@https://github.com/hmcts/div-pay-client#6.2.1":
-  version "6.2.1"
-  resolved "https://github.com/hmcts/div-pay-client#011f72cc8702c4ee50e7308f3cfb82cbe3f2d200"
+"@hmcts/div-pay-client@https://github.com/hmcts/div-pay-client#7.0.0":
+  version "7.0.0"
+  resolved "https://github.com/hmcts/div-pay-client#84e0569c38c55ec63e7c2e272ffa9b57926d726b"
   dependencies:
     "@hmcts/nodejs-logging" "^3.0.0"
+    lodash "^4.17.15"
     request "^2.81.0"
     request-promise-native "^1.0.5"
 


### PR DESCRIPTION
# Description

Using the latest version of div-pay-client, 7.0.0 has fixed all security issue, upgraded all packages and nodejs is upgraded to 10.15.2

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
