### PR TITLE
DIV-5756 - Enable webchat on live environment

### DIFF
--- a/charts/div-pfe/values.preview.template.yaml
+++ b/charts/div-pfe/values.preview.template.yaml
@@ -14,7 +14,6 @@ nodejs:
         FEATURE_STRATEGIC_PAY: "false"
         REDISCLOUD_URL: "redis://${SERVICE_NAME}-redis-master:6379"
         PUBLIC_HOSTNAME: "https://${SERVICE_NAME}.service.core-compute-preview.internal"
-        FEATURE_WEBCHAT: "true"
     keyVaults:
         div:
             secrets:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -91,7 +91,7 @@ features:
   ignoreSessionValidation: false
   browserSupport: false
   strategicPay: false
-  webchat: false
+  webchat: true
 
 idamArgs:
   redirectUri: 'https://localhost:3000/authenticated'

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -260,7 +260,7 @@ variable "decree_nisi_frontend_url" {
 }
 
 variable "feature_webchat" {
-  default = false
+  default = true
 }
 
 variable "webchat_chat_id" {


### PR DESCRIPTION
# Description

[DIV-5756 - Enable webchat on live environment](https://tools.hmcts.net/jira/browse/DIV-5756)
 - Remove chart specific config
 - Set webchat default to true
 - Set webchat default on true for PROD and AAT environments