### PR TITLE
exclude AddressLookupStep/mocks/postcodeInfo.js from sonar checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectVersion=0.0.1
 sonar.sources=app
 sonar.tests=test
 sonar.language=js
-sonar.exclusions=app/assets/**, app/**/*.test.js, test/**, **/healthcheck.js, app/steps/save-resume/confirm-remove-saved-application/index.js, app/middleware/draftPetitionStoreMiddleware.js, app/steps/sitemap/client.js, app/steps/error-400/template.html, app/steps/error-404/template.html, app/views/question.html, app/steps/marriage/upload/template.html, app/steps/check-your-answers/template.html
+sonar.exclusions=app/assets/**, app/**/*.test.js, test/**, **/healthcheck.js, app/steps/save-resume/confirm-remove-saved-application/index.js, app/middleware/draftPetitionStoreMiddleware.js, app/steps/sitemap/client.js, app/steps/error-400/template.html, app/steps/error-404/template.html, app/views/question.html, app/steps/marriage/upload/template.html, app/steps/check-your-answers/template.html, app/components/AddressLookupStep/mocks/postcodeInfo.js
 sonar.dynamicAnalysis=reuseReports
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
# Description

Fix sonar coverage check by excluding mock file.

