### PR TITLE
DIV-5747- Change Gov Panel to accessible Green for all service

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -264,3 +264,7 @@ input.link{
 .govuk-related-items .govuk-heading-s {
   @include govuk-responsive-margin(1, "bottom");
 }
+
+.govuk-panel--confirmation {
+  background: govuk-colour("green") !important;
+}


### PR DESCRIPTION
# Description

[DIV-5747- Change Gov Panel to accessible Green for all services](https://tools.hmcts.net/jira/browse/DIV-5747)
 - Use latest look-and-feel ( which updates confirm panel colour )