### PR TITLE
RPET-58: Remove the deprecated enableDockerBuild() configuration

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -28,7 +28,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 
 withPipeline("nodejs", product, component) {
-  enableDockerBuild()
   installCharts()
   enableAksStagingDeployment()
   disableLegacyDeployment()


### PR DESCRIPTION
# Description

`enableDockerBuild() is deprecated, a Dockerfile has been mandatory since 17/12/2019, please remove this option from your Jenkinsfile This configuration will stop working by 18/02/2020 00:00 AM ( in 10 days )`

Fixes https://tools.hmcts.net/jira/browse/RPET-58

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
