### PR TITLE
cookies-error test fix

### DIFF
--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -11,13 +11,13 @@ Scenario('Incorrect URLs are served a 404 page', (I) => {
 
 });
 
-Scenario('Redirects to cookie error page if start application with no cookies', async (I) => {
+Scenario('Redirects to login page if start application with no cookies', async (I) => {
   I.amOnLoadedPage('/index');
   I.startApplication();
   I.clearCookie();
   //This simulates a situation where the browser has no cookies even after the middleware tried to set one for testing whether the browser accepts cookies
   I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
-  I.seeCurrentUrlEquals('/cookie-error');
+  I.seeInCurrentUrl('/login?');
 });
 
 Scenario('check cookie error page exists', (I) => {

--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -11,13 +11,22 @@ Scenario('Incorrect URLs are served a 404 page', (I) => {
 
 });
 
-Scenario('Redirects to login page if start application with no cookies', async (I) => {
+Scenario('Redirects to login page on AAT OR cookie error page for PR build on application start and clear cookies', async (I) => {
   I.amOnLoadedPage('/index');
   I.startApplication();
   I.clearCookie();
   //This simulates a situation where the browser has no cookies even after the middleware tried to set one for testing whether the browser accepts cookies
   I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
-  I.seeInCurrentUrl('/login?');
+
+  let previewUrl = await I.grabCurrentUrl();
+  let splitPath = previewUrl.split('-')[5];
+  let urlContainsPreview = splitPath.split('.');
+
+  if(urlContainsPreview[0] === 'preview'){
+    I.seeCurrentUrlEquals('/cookie-error');
+  }
+  else{I.seeInCurrentUrl('/login?');}
+
 });
 
 Scenario('check cookie error page exists', (I) => {


### PR DESCRIPTION
If we clear cookies it goes to login page, we no more going to see cookie error page on master/AAT.
Only on Preview it's redirecting to cookie-error page.