### PR TITLE
Chore: e2e and crossbrowser version bumps

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -165,8 +165,8 @@ saucelabs:
   username: 'username'
   key: 'privatekey'
   tunnelId: 'reformtunnel'
-  waitForTimeout: 60000
-  smartWait: 5000
+  waitForTimeout: 20000
+  smartWait: 20000
 
 public:
   protocol: 'https'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-validation": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. mocha test/validation/ --reporter spec --recursive --timeout 15000 --exit",
     "test-e2e": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. ./node_modules/.bin/codeceptjs run-multiple parallel -c test/end-to-end/codecept.conf.js --grep @functional --steps --reporter mocha-multi",
     "test-overnight-e2e": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. codeceptjs run -c test/end-to-end/codecept.conf.js --steps",
-    "test-crossbrowser-e2e": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. node_modules/.bin/codeceptjs run-multiple  ${BROWSER_GROUP:-'--all'} -c test/end-to-end/saucelabs.conf.js --steps --reporter mocha-multi",
+    "test-crossbrowser-e2e": "NODE_ENV=testing LOG_LEVEL=OFF NODE_PATH=. node_modules/.bin/codeceptjs run-multiple  ${BROWSER_GROUP:-'--all'} -c test/end-to-end/saucelabs.conf.js --grep @nightly --steps --reporter mocha-multi",
     "lint": "NODE_PATH=. eslint . --fix"
   },
   "pre-commit": [

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -1,31 +1,34 @@
+const LATEST_MAC = 'macOS 10.15';
+const LATEST_WINDOWS = 'Windows 10';
+
 const supportedBrowsers = {
   microsoftIE11: {
     ie11: {
       browserName: 'internet explorer',
       name: 'IE11',
-      platform: 'Windows 10',
-      version: '11.285'
+      platform: LATEST_WINDOWS,
+      version: 'latest'
     }
   },
   microsoftEdge: {
     edge: {
       browserName: 'MicrosoftEdge',
       name: 'Edge_Win10',
-      platform: 'Windows 10',
-      version: '18.17763'
+      platform: LATEST_WINDOWS,
+      version: 'latest'
     }
   },
   chrome: {
     chrome_win_latest: {
       browserName: 'chrome',
       name: 'DIV_WIN_CHROME_LATEST',
-      platform: 'Windows 10',
+      platform: LATEST_WINDOWS,
       version: 'latest'
     },
     chrome_mac_latest: {
       browserName: 'chrome',
       name: 'MAC_CHROME_LATEST',
-      platform: 'macOS 10.13',
+      platform: LATEST_MAC,
       version: 'latest'
     }
   },
@@ -33,13 +36,13 @@ const supportedBrowsers = {
     firefox_win_latest: {
       browserName: 'firefox',
       name: 'WIN_FIREFOX_LATEST',
-      platform: 'Windows 10',
+      platform: LATEST_WINDOWS,
       version: 'latest'
     },
     firefox_mac_latest: {
       browserName: 'firefox',
       name: 'MAC_FIREFOX_LATEST',
-      platform: 'macOS 10.13',
+      platform: LATEST_MAC,
       version: 'latest'
     }
   }

--- a/test/end-to-end/helpers/ElementExist.js
+++ b/test/end-to-end/helpers/ElementExist.js
@@ -4,26 +4,26 @@ const Helper = codecept_helper;
 
 class ElementExist extends Helper {
 
-  checkElementExist(selector) {
+  async checkElementExist(selector) {
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
 
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
-    const isWebDriverIO = typeof this.helpers['WebDriverIO'] !== 'undefined';
+    try {
+      await helper.waitForElement(selector, 3);
+    } catch (e) {
+      console.log('Element Not Found:', selector); /* eslint-disable-line no-console */
+    }
 
     return helper
       ._locate(selector)
       .then(els => {
-        if (isWebDriverIO) {
-          return !!els.value.length;
-        }
         return !!els.length;
       }).catch(err => {
         throw err;
       });
-
   }
 
   getPaymentIsOnStub() {
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
 
     return helper.grabCurrentUrl()
       .then(url => {

--- a/test/end-to-end/helpers/JSWait.js
+++ b/test/end-to-end/helpers/JSWait.js
@@ -2,7 +2,7 @@ class JSWait extends codecept_helper {
 
   _beforeStep(step) {
 
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
 
     // Wait for content to load before checking URL
     if (step.name === 'seeCurrentUrlEquals' || step.name === 'seeInCurrentUrl') {
@@ -11,7 +11,7 @@ class JSWait extends codecept_helper {
   };
 
   async navByClick (text, locator) {
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
     const helperIsPuppeteer = this.helpers['Puppeteer'];
 
     helper.click(text, locator).catch(err => { console.error(err.message); });
@@ -25,7 +25,7 @@ class JSWait extends codecept_helper {
 
   async amOnLoadedPage (url, language ='en') {
     let newUrl = `${url}?lng=${language}`;
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
     const helperIsPuppeteer = this.helpers['Puppeteer'];
 
     if (helperIsPuppeteer) {

--- a/test/end-to-end/helpers/JSWait.js
+++ b/test/end-to-end/helpers/JSWait.js
@@ -35,13 +35,12 @@ class JSWait extends codecept_helper {
 
       helper.page.goto(newUrl).catch(err => {
         console.error(err.message);
-
       });
       await helper.page.waitForNavigation({waitUntil: 'networkidle0'});
 
     } else {
       await helper.amOnPage(newUrl);
-      await helper.waitInUrl(newUrl);
+      await helper.wait(2);
       await helper.waitForElement('body');
     }
   }

--- a/test/end-to-end/helpers/SauceLabsReportingHelper.js
+++ b/test/end-to-end/helpers/SauceLabsReportingHelper.js
@@ -16,7 +16,7 @@ module.exports = function() {
   // Setting test success on SauceLabs
   event.dispatcher.on(event.test.passed, () => {
 
-    let sessionId = container.helpers('WebDriverIO').browser.requestHandler.sessionID;
+    let sessionId = container.helpers('WebDriver').browser.sessionId;
     exec(updateSauceLabsResult('true', sessionId));
 
   });
@@ -24,7 +24,7 @@ module.exports = function() {
   // Setting test failure on SauceLabs
   event.dispatcher.on(event.test.failed, () => {
 
-    let sessionId = container.helpers('WebDriverIO').browser.requestHandler.sessionID;
+    let sessionId = container.helpers('WebDriver').browser.sessionId;
     exec(updateSauceLabsResult('false', sessionId));
 
   });

--- a/test/end-to-end/helpers/SessionHelper.js
+++ b/test/end-to-end/helpers/SessionHelper.js
@@ -17,7 +17,7 @@ const availableSessions = {
 class SessionHelper extends codecept_helper {
 
   async getTheSession(connectSidCookie, authTokenCookie) {
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
     const proxyUrl = process.env.E2E_PROXY_SERVER ? `http://${process.env.E2E_PROXY_SERVER}` : '';
     let cookieHeaders = {'Cookie': `${connectSidCookie.name}=${connectSidCookie.value}`};
 
@@ -39,7 +39,7 @@ class SessionHelper extends codecept_helper {
   }
 
   async setTheSession (connectSidCookie, authTokenCookie, session) {
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
     const tokens = new Tokens();
     const csrfToken = tokens.create(session.csrfSecret);
     const proxyUrl = process.env.E2E_PROXY_SERVER ? `http://${process.env.E2E_PROXY_SERVER}` : '';
@@ -71,7 +71,7 @@ class SessionHelper extends codecept_helper {
   // of other test's setup.
   //
   async assertSessionEqualsMockTestData() {
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
     const connectSidCookie = await helper.grabCookie('connect.sid');
     const authTokenCookie = await helper.grabCookie('__auth-token');
     const session = await this.getTheSession(connectSidCookie, authTokenCookie);
@@ -107,7 +107,7 @@ class SessionHelper extends codecept_helper {
   }
 
   async haveABasicSession(sessionName) {
-    const helper = this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
     const connectSidCookie = await helper.grabCookie('connect.sid');
     const authTokenCookie = await helper.grabCookie('__auth-token');
     const session = await this.getTheSession(connectSidCookie, authTokenCookie);

--- a/test/end-to-end/paths/reasonsForDivorce.js
+++ b/test/end-to-end/paths/reasonsForDivorce.js
@@ -116,7 +116,7 @@ languages.forEach( language => {
 
   }).retry(2);
 
-  xScenario(`${language.toUpperCase()} - 5 years separation E2E @nightly `, async function(I) {
+  Scenario(`${language.toUpperCase()} - 5 years separation E2E @nightly `, async function(I) {
 
     const divorceReason = language === 'en' ? contentEn : contentCy;
     await loginPageToEnterAddressUsingPostcode(I, language);

--- a/test/end-to-end/paths/reasonsForDivorce.js
+++ b/test/end-to-end/paths/reasonsForDivorce.js
@@ -121,7 +121,7 @@ languages.forEach( language => {
     const divorceReason = language === 'en' ? contentEn : contentCy;
     await loginPageToEnterAddressUsingPostcode(I, language);
     I.selectReasonForDivorce(language, divorceReason['5YearsSeparationHeading']);
-    I.enterSeparationDateNew(fiveYearsAgoFormatted.day, fiveYearsAgoFormatted.month, fiveYearsAgoFormatted.year,
+    I.enterSeparationDateNew(language, fiveYearsAgoFormatted.day, fiveYearsAgoFormatted.month, fiveYearsAgoFormatted.year,
       fiveYearsAgoFormatted.day, fiveYearsAgoFormatted.month, fiveYearsAgoFormatted.year);
     I.selectLivingApartTime(language);
     I.enterLegalProceedings(language);

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -27,7 +27,7 @@ const getBrowserConfig = (browserGroup) => {
 };
 
 const setupConfig = {
-  tests: './paths/**/basicDivorce.js',
+  tests: './paths/**/*.js',
   output: process.cwd() + '/functional-output',
   helpers: {
     WebDriver: {
@@ -37,7 +37,7 @@ const setupConfig = {
       smartWait,
       cssSelectorsEnabled: 'true',
       host: 'ondemand.eu-central-1.saucelabs.com',
-      port: 80,
+      // port: 80,
       region: 'eu',
       user: process.env.SAUCE_USERNAME || CONF.saucelabs.username,
       key: process.env.SAUCE_ACCESS_KEY || CONF.saucelabs.key,

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -3,7 +3,7 @@
 const supportedBrowsers = require('../crossbrowser/supportedBrowsers.js');
 const CONF = require('config');
 
-const waitForTimeout = parseInt(CONF.saucelabs.waitForTimeoutValue);
+const waitForTimeout = parseInt(CONF.saucelabs.waitForTimeout);
 const smartWait = parseInt(CONF.saucelabs.smartWait);
 const browser = process.env.SAUCE_BROWSER || CONF.saucelabs.browser;
 const tunnelName = process.env.SAUCE_TUNNEL_IDENTIFIER || CONF.saucelabs.tunnelId;
@@ -13,6 +13,7 @@ const getBrowserConfig = (browserGroup) => {
     if (candidateBrowser) {
       const desiredCapability = supportedBrowsers[browserGroup][candidateBrowser];
       desiredCapability.tunnelIdentifier = tunnelName;
+      desiredCapability.acceptSslCerts = true;
       desiredCapability.tags = ['divorce'];
       browserConfig.push({
         browser: desiredCapability.browserName,
@@ -29,7 +30,7 @@ const setupConfig = {
   tests: './paths/**/basicDivorce.js',
   output: process.cwd() + '/functional-output',
   helpers: {
-    WebDriverIO: {
+    WebDriver: {
       url: process.env.E2E_FRONTEND_URL || CONF.e2e.frontendUrl,
       browser,
       waitForTimeout,


### PR DESCRIPTION
# Description

This change updates CodeceptJS, Puppeteer and Webdriver to latest or nearly latest stable versions.

As part of this, updates were made to 
- follow CodeceptJS's move to `Webdriver` helper
- fix ElementExist to wait for element
- update crossbrowser tests to run `@nightly` tagged tests instead of hardcoded to _basicDovorce.js_
- fix saucelab.conf.js's waitForTimeout reference
- update supportedBrowsers.js to test on the latest Mac and Windows OSs

Fixes # https://tools.hmcts.net/jira/browse/TA-155

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been run locally against AAT and via Jenkins build, with both passing.


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
