### PR TITLE
Feature: Add retries to idamHelper.js and some e2e tests

### DIFF
--- a/test/end-to-end/helpers/idamHelper.js
+++ b/test/end-to-end/helpers/idamHelper.js
@@ -1,6 +1,6 @@
+/* eslint-disable no-console */
 'use strict';
 
-const logger = require('app/services/logger').logger(__filename);
 const randomstring = require('randomstring');
 const idamExpressTestHarness = require('@hmcts/div-idam-test-harness');
 
@@ -13,42 +13,65 @@ let Helper = codecept_helper;
 
 class IdamHelper extends Helper {
 
-  _before() {
+  async _before() {
     if (parseBool(CONF.features.idam)) {
-      const randomString = randomstring.generate({
-        length: 16,
-        charset: 'numeric'
-      });
-      const emailName = `divorce+pfe-test-${randomString}`;
-      const testEmail = `${emailName}@mailinator.com`;
-      const testPassword = 'genericPassword123';
+      // Codecept doesn't retry _before() steps even if a .retry() is added to the Scenario.
+      // So the below will retry creating a test user if IDAM fails.
+      const maxRetries = 2;
+      let i;
+      for (i = 1; i <= maxRetries; i++) {
 
-      args.testEmail = testEmail;
-      args.testPassword = testPassword;
-      args.testGroupCode = 'citizens';
-      args.roles = [{ code: 'citizen' }];
-
-      idamConfigHelper.setTestEmail(testEmail);
-      idamConfigHelper.setTestPassword(testPassword);
-
-      return idamExpressTestHarness.createUser(args, process.env.E2E_IDAM_PROXY)
-        .then(() => {
-          logger.infoWithReq(null, 'idam_user_created', 'Created IDAM test user', testEmail);
-        }).catch((err) => {
-          logger.warnWithReq(null, 'idam_user_create_error', 'Unable to create IDAM test user', err);
-          throw err ;
-        });
+        try {
+          console.log(`Creating IDAM test user (attempt ${i} of ${maxRetries+1})...`);
+          await this.createUser();
+          break;
+        } catch (err) {
+          if (i < maxRetries) {
+            console.log('Failed to create IDAM test user. Retrying...');
+          } else {
+            console.error(`ERROR: Could not create IDAM test user after '${i+1}' attempts.`);
+            throw err ;
+          }
+        }
+      }
     }
+  }
+
+  createUser() {
+    const randomString = randomstring.generate({
+      length: 16,
+      charset: 'numeric'
+    });
+    const emailName = `divorce+pfe-test-${randomString}`;
+    const testEmail = `${emailName}@mailinator.com`;
+    const testPassword = 'genericPassword123';
+
+    args.testEmail = testEmail;
+    args.testPassword = testPassword;
+    args.testGroupCode = 'citizens';
+    args.roles = [{ code: 'citizen' }];
+
+    idamConfigHelper.setTestEmail(testEmail);
+    idamConfigHelper.setTestPassword(testPassword);
+
+    return idamExpressTestHarness.createUser(args, process.env.E2E_IDAM_PROXY)
+      .then(() => {
+        console.log('Created IDAM test user:', testEmail);
+      }).catch((err) => {
+        console.error('ERROR: Unable to create IDAM test user:', err);
+        throw err ;
+      });
   }
 
   _after() {
     if (parseBool(CONF.features.idam)) {
+      console.log('Removing IDAM test user...');
+      const testEmail = args.testEmail;
       idamExpressTestHarness.removeUser(args, process.env.E2E_IDAM_PROXY)
         .then(() => {
-          logger.infoWithReq(null, 'idam_user_removed', 'Removed IDAM test user', args.testEmail);
+          console.log('IDAM test user removed:', testEmail);
         }).catch((err) => {
-          logger.warnWithReq(null, 'idam_user_remove_error', 'Unable to remove IDAM test user', err);
-          throw err;
+          console.error('ERROR: Unable to remove IDAM test user:', err);
         });
     }
   }

--- a/test/end-to-end/paths/amend.js
+++ b/test/end-to-end/paths/amend.js
@@ -1,4 +1,4 @@
-Feature('Amend petition @functional');
+Feature('Amend petition @functional').retry(2);
 
 Scenario('Submit an amend petition with an existing statement of truth stops at Check Your Answers', async function(I) {
   I.startApplicationWith('amendPetitionSessionWithConfirmation');

--- a/test/end-to-end/paths/serviceApplicationNotApproved.js
+++ b/test/end-to-end/paths/serviceApplicationNotApproved.js
@@ -1,7 +1,7 @@
 const content = require('app/steps/service-application-not-approved/content.json').resources.en.translation.content;
 const infoToContactRespondent = content.infoToContactRespondent.replace('{{ divorceWho }}', 'husband');
 
-Feature('Service Application Rejected - Deemed @functional');
+Feature('Service Application Rejected - Deemed @functional').retry(2);
 
 Scenario('Service application not approved screen with expected information', async function (I) {
 


### PR DESCRIPTION
## Description

TLDR: Add retries to idamHelper.js for the e2e tests, and `.retry(2)` to @functional tagged tests that didn't already have them to better handle AAT dependency issues.

**Changes:**

1. It turns out Codecept doesn't retry `_before()` hooks, so any time an IDAM user creation failed it would fail the test. So this refactor adds 2 retries (i.e. up to 3 attempts) to create a user.
2. Tests were failign when removing IDAM test users, but this has nothing to do with Divorce functionality as it's just test cleanup. So errors experienced during IDAM test user removal will now be printed to logs but not thrown.
3. The previous logging method didn't actually print anything anywhere, making debugging very difficult. So this will now report to console logs both successful and unsuccessful attempts, plus which retry it's doing.
4. Some @functional tagged tests weren't being retries if they failed for a random reason, so they'll now be allowed to retry in line with the other e2e tests.


Fixes # (issue) broken master

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested several times locally and correctly handles both successful and unsuccessful retries.

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
