### PR TITLE
Fix: Crossbrowser IE and Safari tests (v4)

### DIFF
--- a/bin/run-crossbrowser-tests.sh
+++ b/bin/run-crossbrowser-tests.sh
@@ -12,5 +12,6 @@ BROWSER_GROUP=microsoftIE11 yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 BROWSER_GROUP=microsoftEdge yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 BROWSER_GROUP=chrome yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 BROWSER_GROUP=firefox yarn test-crossbrowser-e2e || EXIT_STATUS=$?
+BROWSER_GROUP=safari yarn test-crossbrowser-e2e || EXIT_STATUS=$?
 echo EXIT_STATUS: $EXIT_STATUS
 exit $EXIT_STATUS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -110,6 +110,10 @@ e2e:
   waitForActionValue: E2E_WAIT_FOR_ACTION_VALUE
   runBasicTests: RUN_BASIC_TESTS
 
+saucelabs:
+  waitForTimeout: SAUCELABS_WAIT_FOR_TIMEOUT_VALUE
+  smartWait: SAUCELABS_SMART_WAIT_VALUE
+
 testUrl: TEST_URL
 divorceHttpProxy: DIVORCE_HTTP_PROXY
 

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -9,7 +9,7 @@ const supportedBrowsers = {
       browserVersion: 'latest',
       'sauce:options': {
         name: 'IE11',
-        screenResolution: '1280x1024'
+        screenResolution: '1400x1050'
       }
     }
   },
@@ -20,6 +20,18 @@ const supportedBrowsers = {
       browserVersion: 'latest',
       'sauce:options': {
         name: 'Edge_Win10'
+      }
+    }
+  },
+  safari: {
+    safari_mac_latest: {
+      browserName: 'safari',
+      platformName: LATEST_MAC,
+      browserVersion: 'latest',
+      'sauce:options': {
+        name: 'MAC_SAFARI_LATEST',
+        seleniumVersion: '3.141.59',
+        screenResolution: '1400x1050'
       }
     }
   },

--- a/test/end-to-end/helpers/ElementExist.js
+++ b/test/end-to-end/helpers/ElementExist.js
@@ -34,6 +34,11 @@ class ElementExist extends Helper {
       });
   }
 
+  async getBrowserName() {
+    const helper = this.helpers['WebDriver'] || this.helpers['Puppeteer'];
+    return await helper.options.browser;
+  }
+
 }
 
 module.exports = ElementExist;

--- a/test/end-to-end/helpers/SauceLabsBrowserHelper.js
+++ b/test/end-to-end/helpers/SauceLabsBrowserHelper.js
@@ -1,0 +1,36 @@
+const Helper = codecept_helper;
+
+class SauceLabsBrowserHelper extends Helper {
+
+  _before() {
+    const webdriver = this.helpers['WebDriver'];
+    if (webdriver) {
+      if (webdriver.config.browser === 'internet explorer') {
+        console.log('Increasing IE11 browser window size'); /* eslint-disable-line no-console */
+        webdriver.browser.setWindowSize(1280, 960);
+      }
+    }
+  }
+
+  async _beforeStep(step) {
+    const webdriver = this.helpers['WebDriver'];
+    if (webdriver) {
+      if (webdriver.config.browser === 'internet explorer') {
+        // Allow IE to catch up before doing certain steps
+        if (['waitInUrl', 'selectOption', 'waitForVisible'].includes(step.name)) {
+          return await webdriver.wait(1);
+        }
+      }
+
+      if (webdriver.config.browser === 'safari') {
+        // Allow Safari to catch up doing certain steps
+        if (['checkOption'].includes(step.name)) {
+          return await webdriver.wait(1);
+        }
+      }
+    }
+  }
+
+}
+
+module.exports = SauceLabsBrowserHelper;

--- a/test/end-to-end/paths/jurisdictionConnections.js
+++ b/test/end-to-end/paths/jurisdictionConnections.js
@@ -1,22 +1,8 @@
 const language ='en';
 Feature('New Jurisdiction Journeys @functional').retry(3);
 
-Before((I) => {
-  I.amOnLoadedPage('/');
-  I.startApplication();
-  I.languagePreference();
-  I.haveBrokenMarriage();
-  I.haveRespondentAddress();
-  I.haveMarriageCert();
-
-  I.readFinancialRemedy();
-  I.selectHelpWithFees(language, false);
-  I.selectDivorceType();
-  I.enterMarriageDate();
-  I.selectMarriedInUk();
-});
-
-Scenario('Set A & C: Both Habitually Resident', function(I) {
+Scenario('Set A & C: Both Habitually Resident', async function(I) {
+  await completeLoginPageToSelectMarriedInUk(I);
   I.chooseBothHabituallyResident(language);
   I.chooseJurisdictionInterstitialContinue();
   I.seeInCurrentUrl('/petitioner-respondent/confidential');
@@ -24,7 +10,8 @@ Scenario('Set A & C: Both Habitually Resident', function(I) {
   I.checkMyConnectionsAre('A', 'C');
 });
 
-Scenario('Set All: Selected via Last Resort page', function(I) {
+Scenario('Set All: Selected via Last Resort page', async function(I) {
+  await completeLoginPageToSelectMarriedInUk(I);
   I.chooseRespondentHabituallyResident(language);
   I.chooseJurisdictionInterstitialNeedInfo();
   I.chooseBothDomiciled();
@@ -37,7 +24,8 @@ Scenario('Set All: Selected via Last Resort page', function(I) {
   I.checkMyConnectionsAre('A', 'B', 'C', 'D', 'E', 'F', 'G');
 }).retry(3);
 
-xScenario('Re-set connections: Not confident at Connection Summary 1st time', function(I) {
+xScenario('Re-set connections: Not confident at Connection Summary 1st time', async function(I) {
+  await completeLoginPageToSelectMarriedInUk(I);
   I.choosePetitionerHabituallyResident(language);
   I.chooseYesJurisdictionLastTwelveMonths();
   I.chooseJurisdictionInterstitialNeedInfo();
@@ -56,7 +44,8 @@ xScenario('Re-set connections: Not confident at Connection Summary 1st time', fu
   I.checkMyConnectionsAre('G');
 }).retry(3);
 
-xScenario('Jurisdiction Exit: Petitioner does not have eligible jurisdiction.', function(I) {
+xScenario('Jurisdiction Exit: Petitioner does not have eligible jurisdiction.', async function(I) {
+  await completeLoginPageToSelectMarriedInUk(I);
   I.choosePetitionerHabituallyResident(language);
   I.chooseNoJurisdictionLastTwelveMonths();
   I.choosePetitionerDomiciled();
@@ -65,3 +54,17 @@ xScenario('Jurisdiction Exit: Petitioner does not have eligible jurisdiction.', 
   I.chooseNoForResidualJurisdiction();
   I.seeInCurrentUrl('/exit/jurisdiction/no-cnnections');
 }).retry(3);
+
+async function completeLoginPageToSelectMarriedInUk(I) {
+  await I.amOnLoadedPage('/');
+  I.startApplication();
+  I.languagePreference();
+  I.haveBrokenMarriage();
+  I.haveRespondentAddress();
+  I.haveMarriageCert();
+  I.readFinancialRemedy();
+  I.selectHelpWithFees(language, false);
+  I.selectDivorceType();
+  I.enterMarriageDate();
+  I.selectMarriedInUk();
+}

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -47,6 +47,7 @@ const setupConfig = {
       region: 'eu',
       capabilities: {}
     },
+    SauceLabsBrowserHelper: { require: './helpers/SauceLabsBrowserHelper.js' },
     SauceLabsReportingHelper: { require: './helpers/SauceLabsReportingHelper.js' },
     JSWait: { require: './helpers/JSWait.js' },
     ElementExist: { require: './helpers/ElementExist.js' },
@@ -86,6 +87,9 @@ const setupConfig = {
     },
     firefox: {
       browsers: getBrowserConfig('firefox')
+    },
+    safari: {
+      browsers: getBrowserConfig('safari')
     }
   },
   name: 'PFE Frontend Tests'


### PR DESCRIPTION
# Description

This change includes everything needed to get the crossbrowser tests running stably for Internet Explorer and Safari via Saucelabs:

- add latest Safari on latest Mac to crossbrowser test list
- move test setup out of `Before()` hook because Codecept doesn't retry these steps if there's a failure
- increase screen resolution for Safari and IE as the tests were more susceptible to being flakey on smaller browser windows (not related to the website functionality)

Fixes # 
https://tools.hmcts.net/jira/browse/TA-163
https://tools.hmcts.net/jira/browse/TA-185

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests have been successfully running via the nightly pipeline

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
