### PR TITLE
DIV-6673: Updating test to treat preview and non-preview URL equally

### DIFF
--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -11,14 +11,23 @@ Scenario('Incorrect URLs are served a 404 page', (I) => {
 
 });
 
-Scenario('Redirects to login page if start application with no cookies', async (I) => {
+Scenario('Redirects to login page on AAT OR cookie error page for PR build on application start and clear cookies', async (I) => {
   I.amOnLoadedPage('/index');
   I.startApplication();
   I.clearCookie();
   //This simulates a situation where the browser has no cookies even after the middleware tried to set one for testing whether the browser accepts cookies
   I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
 
-  I.seeInCurrentUrl('/login?');
+  let currentUrl = await I.grabCurrentUrl();
+  // eslint-disable-next-line no-console
+  console.log('Current Page Url-->:' + currentUrl);
+
+  if (currentUrl.includes('-preview')) {
+    I.seeCurrentUrlEquals('/cookie-error');
+  }
+  else {
+    I.seeInCurrentUrl('/login?');
+  }
 }).retry(2);
 
 Scenario('check cookie error page exists', (I) => {

--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -11,14 +11,23 @@ Scenario('Incorrect URLs are served a 404 page', (I) => {
 
 });
 
-Scenario('Redirects to login page if start application with no cookies', async (I) => {
+Scenario('Redirects to login page on AAT OR cookie error page for PR build on application start and clear cookies', async (I) => {
   await I.amOnLoadedPage('/index');
   I.startApplication();
   I.clearCookie();
   //This simulates a situation where the browser has no cookies even after the middleware tried to set one for testing whether the browser accepts cookies
   await I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
 
-  I.seeInCurrentUrl('/login?');
+  let currentUrl = await I.grabCurrentUrl();
+  // eslint-disable-next-line no-console
+  console.log('Current Page Url-->:' + currentUrl);
+
+  if (currentUrl.includes('-preview')) {
+    I.seeCurrentUrlEquals('/cookie-error');
+  }
+  else {
+    I.seeInCurrentUrl('/login?');
+  }
 }).retry(2);
 
 Scenario('check cookie error page exists', (I) => {

--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -11,24 +11,14 @@ Scenario('Incorrect URLs are served a 404 page', (I) => {
 
 });
 
-Scenario('Redirects to login page on AAT OR cookie error page for PR build on application start and clear cookies @Nightly', async (I) => {
-  await I.amOnLoadedPage('/index');
+Scenario('Redirects to login page if start application with no cookies', async (I) => {
+  I.amOnLoadedPage('/index');
   I.startApplication();
   I.clearCookie();
   //This simulates a situation where the browser has no cookies even after the middleware tried to set one for testing whether the browser accepts cookies
-  await I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
+  I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
 
-  let previewUrl = await I.grabCurrentUrl();
-  // eslint-disable-next-line no-console
-  console.log('Current Page Url-->:' + previewUrl);
-  let splitPath = previewUrl.split('-')[5];
-  let urlContainsPreview = splitPath.split('.');
-
-  if(urlContainsPreview[0] === 'preview'){
-    I.seeCurrentUrlEquals('/cookie-error');
-  }
-  else{I.seeInCurrentUrl('/login?');}
-
+  I.seeInCurrentUrl('/login?');
 }).retry(2);
 
 Scenario('check cookie error page exists', (I) => {

--- a/test/end-to-end/paths/errorPaths.js
+++ b/test/end-to-end/paths/errorPaths.js
@@ -11,23 +11,14 @@ Scenario('Incorrect URLs are served a 404 page', (I) => {
 
 });
 
-Scenario('Redirects to login page on AAT OR cookie error page for PR build on application start and clear cookies', async (I) => {
-  I.amOnLoadedPage('/index');
+Scenario('Redirects to login page if start application with no cookies', async (I) => {
+  await I.amOnLoadedPage('/index');
   I.startApplication();
   I.clearCookie();
   //This simulates a situation where the browser has no cookies even after the middleware tried to set one for testing whether the browser accepts cookies
-  I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
+  await I.amOnLoadedPage('/authenticated?attemptToSetTestCookie=true');
 
-  let currentUrl = await I.grabCurrentUrl();
-  // eslint-disable-next-line no-console
-  console.log('Current Page Url-->:' + currentUrl);
-
-  if (currentUrl.includes('-preview')) {
-    I.seeCurrentUrlEquals('/cookie-error');
-  }
-  else {
-    I.seeInCurrentUrl('/login?');
-  }
+  I.seeInCurrentUrl('/login?');
 }).retry(2);
 
 Scenario('check cookie error page exists', (I) => {


### PR DESCRIPTION
# Description

I think this was put in place as a temporary workaround. It seems reasonable to me that we don't see a cookie error page when trying to log in any environment.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test was updated.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
