### PR TITLE
Remove invalid frame-src attribute in CSP

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,7 +65,6 @@ exports.init = listenForConnections => {
       connectSrc: ['\'self\''],
       mediaSrc: ['\'self\''],
       frameSrc: [
-        '\'none\'',
         'vcc-eu4.8x8.com',
         'vcc-eu4b.8x8.com'
       ],


### PR DESCRIPTION
> chat.js:1 The source list for Content Security Policy directive 'frame-src' contains an invalid source: ''none''. It will be ignored. Note that 'none' has no effect unless it is the only expression in the source list.

Noticed in production logs in dynatrace and in my browser console