### PR TITLE
DIV-6760: Solicitor email mandatory during organisation lookup

### DIFF
--- a/app/core/utils/respondentSolicitorSearchHelper.js
+++ b/app/core/utils/respondentSolicitorSearchHelper.js
@@ -1,4 +1,4 @@
-const { get, trim, isEmpty, size, isUndefined, isEqual } = require('lodash');
+const { get, trim, isEmpty, size, isUndefined } = require('lodash');
 const organisationService = require('app/services/organisationService');
 const serviceTokenService = require('app/services/serviceToken');
 const logger = require('app/services/logger').logger(__filename);
@@ -97,7 +97,7 @@ const validateUserData = (content, req) => {
   }
 
   if (isEmpty(solicitorEmail)) {
-    errors.push({ key: 'respondentSolicitorEmailError', errorMessage: getErrorMessage[ErrorMessage.SOLICITOR_EMAIL, content, session] });
+    errors.push({ key: 'respondentSolicitorEmailError', errorMessage: getErrorMessage(ErrorMessage.SOLICITOR_EMAIL, content, session) });
   }
 
   return errors;

--- a/app/core/utils/respondentSolicitorSearchHelper.js
+++ b/app/core/utils/respondentSolicitorSearchHelper.js
@@ -17,7 +17,8 @@ const UserAction = {
 const ErrorMessage = {
   EMPTY_VALUE: 'emptyValue',
   SHORT_VALUE: 'shortValue',
-  SOLICITOR_NAME: 'solicitorName'
+  SOLICITOR_NAME: 'solicitorName',
+  SOLICITOR_EMAIL: 'solicitorEmail'
 };
 
 const getServiceAuthToken = req => {
@@ -85,16 +86,21 @@ const validateSearchRequest = (searchCriteria, content, session) => {
   return [true, null];
 };
 
-const validateUserData = (content, req, userAction) => {
+const validateUserData = (content, req) => {
   const { body, session } = req;
   const solicitorName = get(body, 'respondentSolicitorName');
+  const solicitorEmail = get(body, 'respondentSolicitorEmail');
+  let errors = [];
 
-  if (isEqual(userAction, UserAction.PROVIDED) && isEmpty(solicitorName)) {
-    const errorMessage = getErrorMessage(ErrorMessage.SOLICITOR_NAME, content, session);
-    return [false, { error: true, errorMessage }];
+  if(isEmpty(solicitorName)) {
+    errors.push({key: 'respondentSolicitorNameError', errorMessage: getErrorMessage(ErrorMessage.SOLICITOR_NAME, content, session)})
   }
 
-  return [true, null];
+  if (isEmpty(solicitorEmail)) {
+    errors.push({key: 'respondentSolicitorEmailError', errorMessage: getErrorMessage[ErrorMessage.SOLICITOR_EMAIL, content, session]});
+  }
+  
+  return errors;
 };
 
 const hasBeenPostedWithoutSubmitButton = ({ body }) => {

--- a/app/core/utils/respondentSolicitorSearchHelper.js
+++ b/app/core/utils/respondentSolicitorSearchHelper.js
@@ -90,16 +90,16 @@ const validateUserData = (content, req) => {
   const { body, session } = req;
   const solicitorName = get(body, 'respondentSolicitorName');
   const solicitorEmail = get(body, 'respondentSolicitorEmail');
-  let errors = [];
+  const errors = [];
 
-  if(isEmpty(solicitorName)) {
-    errors.push({key: 'respondentSolicitorNameError', errorMessage: getErrorMessage(ErrorMessage.SOLICITOR_NAME, content, session)})
+  if (isEmpty(solicitorName)) {
+    errors.push({ key: 'respondentSolicitorNameError', errorMessage: getErrorMessage(ErrorMessage.SOLICITOR_NAME, content, session) });
   }
 
   if (isEmpty(solicitorEmail)) {
-    errors.push({key: 'respondentSolicitorEmailError', errorMessage: getErrorMessage[ErrorMessage.SOLICITOR_EMAIL, content, session]});
+    errors.push({ key: 'respondentSolicitorEmailError', errorMessage: getErrorMessage[ErrorMessage.SOLICITOR_EMAIL, content, session] });
   }
-  
+
   return errors;
 };
 

--- a/app/core/utils/respondentSolicitorSearchHelper.test.js
+++ b/app/core/utils/respondentSolicitorSearchHelper.test.js
@@ -15,7 +15,8 @@ const {
 const Errors = {
   EMPTY_SOLICITOR_SEARCH: 'emptyValue',
   SHORT_SOLICITOR_SEARCH: 'shortValue',
-  EMPTY_SOLICITOR_NAME: 'solicitorName'
+  EMPTY_SOLICITOR_NAME: 'solicitorName',
+  EMPTY_SOLICITOR_EMAIL: 'solicitorEmail'
 };
 
 const content = {
@@ -26,7 +27,8 @@ const content = {
           searchErrors: {
             emptyValue: Errors.EMPTY_SOLICITOR_SEARCH,
             shortValue: Errors.SHORT_SOLICITOR_SEARCH,
-            solicitorName: Errors.EMPTY_SOLICITOR_NAME
+            solicitorName: Errors.EMPTY_SOLICITOR_NAME,
+            solicitorEmail: Errors.EMPTY_SOLICITOR_EMAIL
           }
         }
       }
@@ -154,45 +156,55 @@ describe(modulePath, () => {
   });
 
   describe('validateUserData()', () => {
-    const UserAction = {
-      MANUAL: 'manual',
-      SEARCH: 'search',
-      SELECTION: 'selection',
-      DESELECTION: 'deselection',
-      PROVIDED: 'provided'
-    };
-
-    it('should return no errors when respondentSolicitorName has been populated', () => {
+    it('should return no errors when respondentSolicitorName and respondentSolicitorEmail have been populated', () => {
       req = {
         body: {
-          respondentSolicitorName: 'Karen Fox Solicitor'
+          respondentSolicitorName: 'Karen Fox Solicitor',
+          respondentSolicitorEmail: 'test@email.com'
         },
         session: { language: 'en' }
       };
 
-      expect(validateUserData(content, req, UserAction.PROVIDED)).to.deep.equal([true, null]);
+      expect(validateUserData(content, req)).to.deep.equal([]);
     });
 
     it('should return EMPTY_SOLICITOR_NAME error message when respondentSolicitorName is an empty string', () => {
       req = {
         body: {
-          respondentSolicitorName: ''
+          respondentSolicitorName: '',
+          respondentSolicitorEmail: 'test@email.com'
         },
         session: { language: 'en' }
       };
 
-      expect(validateUserData(content, req, UserAction.PROVIDED))
-        .to.deep.equal([false, { error: true, errorMessage: Errors.EMPTY_SOLICITOR_NAME }]);
+      expect(validateUserData(content, req))
+        .to.deep.equal([{ key: 'respondentSolicitorNameError', errorMessage: Errors.EMPTY_SOLICITOR_NAME }]);
     });
 
-    it('should return EMPTY_SOLICITOR_NAME error message when respondentSolicitorName has not been provided', () => {
+    it('should return EMPTY_SOLICITOR_EMAIL error message when respondentSolicitorEmail is an empty string', () => {
+      req = {
+        body: {
+          respondentSolicitorName: 'Karen Fox Solicitor',
+          respondentSolicitorEmail: ''
+        },
+        session: { language: 'en' }
+      };
+
+      expect(validateUserData(content, req))
+        .to.deep.equal([{ key: 'respondentSolicitorEmailError', errorMessage: Errors.EMPTY_SOLICITOR_EMAIL }]);
+    });
+
+    it('should return EMPTY_SOLICITOR_NAME and EMPTY_SOLICITOR_EMAIL error message when respondentSolicitorName and respondentSolicitorEmail have not been provided', () => {
       req = {
         body: {},
         session: { language: 'en' }
       };
 
-      expect(validateUserData(content, req, UserAction.PROVIDED))
-        .to.deep.equal([false, { error: true, errorMessage: Errors.EMPTY_SOLICITOR_NAME }]);
+      expect(validateUserData(content, req))
+        .to.deep.equal([
+          { key: 'respondentSolicitorNameError', errorMessage: Errors.EMPTY_SOLICITOR_NAME },
+          { key: 'respondentSolicitorEmailError', errorMessage: Errors.EMPTY_SOLICITOR_EMAIL }
+        ]);
     });
   });
 });

--- a/app/steps/respondent/correspondence/solicitor-search/content.json
+++ b/app/steps/respondent/correspondence/solicitor-search/content.json
@@ -14,7 +14,7 @@
           "resultsLabel": "Results",
           "solicitorNameLabel": "Solicitor's name",
           "solicitorReferenceLabel": "Solicitor's reference (optional)",
-          "solicitorEmailLabel": "Solicitor's email address (optional)",
+          "solicitorEmailLabel": "Solicitor's email address",
           "solicitorFirmAddressLabel": "Solicitor's firm and address",
           "searchNoOptionFoundText": "If you can't see the firm listed then you can enter the details manually.",
           "searchNoResults": {
@@ -25,7 +25,8 @@
           "searchErrors": {
             "emptyValue": "Please provide a solicitor firm's name",
             "shortValue": "Please provide at least 3 characters",
-            "solicitorName": "Please provide a solicitor name"
+            "solicitorName": "Please provide a solicitor name",
+            "solicitorEmail": "Please provide a solicitor email"
           }
         },
         "errors": {
@@ -49,7 +50,7 @@
           "resultsLabel": "[CY] Results",
           "solicitorNameLabel": "[CY] Solicitor's name",
           "solicitorReferenceLabel": "[CY] Solicitor's reference (optional)",
-          "solicitorEmailLabel": "[CY] Solicitor's email address (optional)",
+          "solicitorEmailLabel": "[CY] Solicitor's email address",
           "solicitorFirmAddressLabel": "[CY] Solicitor's firm and address",
           "searchNoOptionFoundText": "[CY] If you can't see the firm listed then you can enter the details manually.",
           "searchNoResults": {
@@ -59,7 +60,9 @@
           },
           "searchErrors": {
             "emptyValue": "[CY] Please provide your solicitor firm's name",
-            "shortValue": "[CY] Please provide at least 3 characters"
+            "shortValue": "[CY] Please provide at least 3 characters",
+            "solicitorName": "[CY] Please provide a solicitor name",
+            "solicitorEmail": "[CY] Please provide a solicitor email"
           }
         },
         "errors": {

--- a/app/steps/respondent/correspondence/solicitor-search/index.js
+++ b/app/steps/respondent/correspondence/solicitor-search/index.js
@@ -62,9 +62,9 @@ module.exports = class RespondentCorrespondenceSolicitorSearch extends Validatio
         const errors = validateUserData(this.content, req, userAction);
 
         if (errors) {
-          errors.map(error => { 
+          errors.map(error => {
             console.log(error.errorMessage);
-            req.session[error.key] = [error.errorMessage]; 
+            req.session[error.key] = [error.errorMessage];
           });
 
           console.log(req.session);

--- a/app/steps/respondent/correspondence/solicitor-search/index.js
+++ b/app/steps/respondent/correspondence/solicitor-search/index.js
@@ -6,9 +6,7 @@ const {
   validateSearchRequest,
   validateUserData,
   fetchAndAddOrganisations,
-  hasBeenPostedWithoutSubmitButton
-} = require('app/core/utils/respondentSolicitorSearchHelper');
-const { errors } = require('puppeteer');
+  hasBeenPostedWithoutSubmitButton} = require('app/core/utils/respondentSolicitorSearchHelper');
 
 module.exports = class RespondentCorrespondenceSolicitorSearch extends ValidationStep {
   get url() {
@@ -61,14 +59,11 @@ module.exports = class RespondentCorrespondenceSolicitorSearch extends Validatio
       if (isEqual(userAction, UserAction.PROVIDED)) {
         const errors = validateUserData(this.content, req, userAction);
 
-        if (errors) {
+        if (errors.length) {
           errors.map(error => {
-            console.log(error.errorMessage);
-            req.session[error.key] = [error.errorMessage];
+            req.session[error.key] = { error: true, errorMessage: error.errorMessage };
+            return error;
           });
-
-          console.log(req.session);
-
           return res.redirect(this.url);
         }
 
@@ -101,6 +96,7 @@ module.exports = class RespondentCorrespondenceSolicitorSearch extends Validatio
   errorsCleanup(req) {
     req.session.respondentSolicitorNameError = null;
     req.session.respondentSolicitorFirmError = null;
+    req.session.respondentSolicitorEmailError = null;
   }
 
   mapRespondentSolicitorData({ session }) {

--- a/app/steps/respondent/correspondence/solicitor-search/index.js
+++ b/app/steps/respondent/correspondence/solicitor-search/index.js
@@ -8,6 +8,7 @@ const {
   fetchAndAddOrganisations,
   hasBeenPostedWithoutSubmitButton
 } = require('app/core/utils/respondentSolicitorSearchHelper');
+const { errors } = require('puppeteer');
 
 module.exports = class RespondentCorrespondenceSolicitorSearch extends ValidationStep {
   get url() {
@@ -58,9 +59,16 @@ module.exports = class RespondentCorrespondenceSolicitorSearch extends Validatio
       }
 
       if (isEqual(userAction, UserAction.PROVIDED)) {
-        const [isValid, errors] = validateUserData(this.content, req, userAction);
-        if (!isValid) {
-          req.session.respondentSolicitorNameError = errors;
+        const errors = validateUserData(this.content, req, userAction);
+
+        if (errors) {
+          errors.map(error => { 
+            console.log(error.errorMessage);
+            req.session[error.key] = [error.errorMessage]; 
+          });
+
+          console.log(req.session);
+
           return res.redirect(this.url);
         }
 

--- a/app/steps/respondent/correspondence/solicitor-search/index.test.js
+++ b/app/steps/respondent/correspondence/solicitor-search/index.test.js
@@ -18,6 +18,7 @@ let agent = {};
 let underTest = {};
 
 const TEST_RESP_SOLICITOR_NAME = 'RespondentSolicitor';
+const TEST_RESP_SOLICITOR_EMAIL = 'testemail';
 const TEST_RESP_SOLICITOR_REF = 'SOL-REF';
 const TEST_RESP_SOLICITOR_COMPANY = 'Whitehead & Low Solicitors LLP';
 const TEST_RESP_SOLICITOR_ID = '11-111';
@@ -26,6 +27,7 @@ function buildRespondentSolicitorSessionData() {
   return {
     divorceWho: 'wife',
     respondentSolicitorName: TEST_RESP_SOLICITOR_NAME,
+    respondentSolicitorEmail: TEST_RESP_SOLICITOR_EMAIL,
     respondentSolicitorReference: TEST_RESP_SOLICITOR_REF,
     respondentSolicitorOrganisation: {
       contactInformation: [
@@ -82,7 +84,8 @@ describe(modulePath, () => {
           'searchNoResults.paragraph3',
           'searchErrors.emptyValue',
           'searchErrors.shortValue',
-          'searchErrors.solicitorName'
+          'searchErrors.solicitorName',
+          'searchErrors.solicitorEmail'
         ];
 
         testContent(done, agent, underTest, content, session, excludedKeys);
@@ -113,7 +116,8 @@ describe(modulePath, () => {
       it('should redirect when user action is PROVIDED and data is provided', done => {
         testRedirect(done, agent, underTest, {
           userAction: 'provided',
-          respondentSolicitorName: 'testSolicitorName'
+          respondentSolicitorName: 'testSolicitorName',
+          respondentSolicitorEmail: 'testSolicitorEmail'
         }, s.steps.ReasonForDivorce);
       });
     });
@@ -140,8 +144,8 @@ describe(modulePath, () => {
       underTest.mapRespondentSolicitorData(req);
 
       expect(req.session.respondentSolicitorName).to.equal(TEST_RESP_SOLICITOR_NAME);
+      expect(req.session.respondentSolicitorEmail).to.equal(TEST_RESP_SOLICITOR_EMAIL);
       expect(req.session.respondentSolicitorReference).to.equal(TEST_RESP_SOLICITOR_REF);
-      expect(req.session).to.not.have.property('respondentSolicitorEmail');
       expect(req.session.respondentSolicitorCompany).to.equal(TEST_RESP_SOLICITOR_COMPANY);
       expect(req.session.respondentSolicitorAddress).to.have.property('address');
       expect(req.session.respondentSolicitorAddress.address).to.have.deep.members(expectedAddress);
@@ -154,8 +158,8 @@ describe(modulePath, () => {
       underTest.mapRespondentSolicitorData(req);
 
       expect(req.session.respondentSolicitorName).to.equal(TEST_RESP_SOLICITOR_NAME);
+      expect(req.session.respondentSolicitorEmail).to.equal(TEST_RESP_SOLICITOR_EMAIL);
       expect(req.session.respondentSolicitorReference).to.equal(TEST_RESP_SOLICITOR_REF);
-      expect(req.session).to.not.have.property('respondentSolicitorEmail');
       expect(req.session.respondentSolicitorCompany).to.be.undefined;
       expect(req.session.respondentSolicitorAddress).to.have.property('address');
       expect(req.session.respondentSolicitorAddress.address).to.have.lengthOf(0);

--- a/app/views/common/components/respondentSolicitorComponents.html
+++ b/app/views/common/components/respondentSolicitorComponents.html
@@ -91,7 +91,7 @@ It decides to render if the "organisations" object is not null, behaviour contro
             autocomplete="off">
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         <input type="hidden" name="userAction" value="provided">
-        <div class="govuk-form-group {{ 'govuk-form-group--error' if session.respondentSolicitorNameError.error }}"
+        <div class="govuk-form-group {{ 'govuk-form-group--error' if session.respondentSolicitorNameError }}"
              id="solicitor-name">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend visually-hidden">{{ content.question | safe }}</legend>
@@ -104,14 +104,16 @@ It decides to render if the "organisations" object is not null, behaviour contro
             ) }}
           </fieldset>
         </div>
-        <div class="govuk-form-group {{ 'govuk-form-group--error' if session.respondentSolicitorEmailError.error }}">
-          {{ errorsFor(session.respondentSolicitorEmailError) }}
-          {{ textField(
-          name = 'respondentSolicitorEmail',
-          field = fields.respondentSolicitorEmail,
-          label = content.solicitorEmailLabel,
-          boldLabel = true
-          ) }}
+        <div class="govuk-form-group {{ 'govuk-form-group--error' if session.respondentSolicitorEmailError }}"
+             id="solicitor-email">
+            <legend class="govuk-fieldset__legend visually-hidden">{{ content.question | safe }}</legend>
+            {{ errorsFor(session.respondentSolicitorEmailError) }}
+            {{ textField(
+            name = 'respondentSolicitorEmail',
+            field = fields.respondentSolicitorEmail,
+            label = content.solicitorEmailLabel,
+            boldLabel = true
+            ) }}
         </div>
         <div class="govuk-form-group">
           {{ textField(

--- a/app/views/common/components/respondentSolicitorComponents.html
+++ b/app/views/common/components/respondentSolicitorComponents.html
@@ -104,6 +104,15 @@ It decides to render if the "organisations" object is not null, behaviour contro
             ) }}
           </fieldset>
         </div>
+        <div class="govuk-form-group {{ 'govuk-form-group--error' if session.respondentSolicitorEmailError.error }}">
+          {{ errorsFor(session.respondentSolicitorEmailError) }}
+          {{ textField(
+          name = 'respondentSolicitorEmail',
+          field = fields.respondentSolicitorEmail,
+          label = content.solicitorEmailLabel,
+          boldLabel = true
+          ) }}
+        </div>
         <div class="govuk-form-group">
           {{ textField(
           name = 'respondentSolicitorReference',

--- a/test/end-to-end/pages/organisation-search/search.js
+++ b/test/end-to-end/pages/organisation-search/search.js
@@ -3,7 +3,8 @@ const commonContentCy = require('app/content/common-cy').resources.cy.translatio
 
 const mockOrganisation = {
   reference: '02-002',
-  name: 'Karen Fox Solicitor'
+  name: 'Karen Fox Solicitor',
+  email: 'karen@karenfox.co.uk'
 };
 
 function enterOrganisationUsingLookup(language = 'en', stepUrl, organisation = mockOrganisation) {
@@ -22,6 +23,7 @@ function enterOrganisationUsingLookup(language = 'en', stepUrl, organisation = m
   I.navByClick(`select-${organisation.reference}`);
   I.wait(4);
   I.fillField('respondentSolicitorName', organisation.name);
+  I.fillField('#respondentSolicitorEmail', organisation.email);
   I.fillField('respondentSolicitorReference', organisation.reference);
   I.wait(2);
   I.navByClick(commonContent.continue);


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-6760

Adds mandatory solicitor email to organisation lookup (currently only available in enter organisation manually)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
