### PR TITLE
DIV-6837: Update check your answers page for respondent solicitor details

### DIFF
--- a/app/core/utils/respondentSolicitorSearchHelper.js
+++ b/app/core/utils/respondentSolicitorSearchHelper.js
@@ -161,14 +161,18 @@ const isManual = session => {
   return isEqual(session.searchType, 'manual');
 };
 
-const parseManualAddress = value => {
-  return value.split(/\r?\n/)
+const trimAndRemoveBlanks = list => {
+  return [].concat(list)
     .map(line => {
       return trim(line);
     })
     .filter(item => {
       return !isEmpty(item);
     });
+};
+
+const parseManualAddress = value => {
+  return trimAndRemoveBlanks(value.split(/\r?\n/));
 };
 
 const mapRespondentSolicitorData = ({ body, session }, manual) => {
@@ -192,6 +196,18 @@ const mapRespondentSolicitorData = ({ body, session }, manual) => {
   session.respondentSolicitorAddress = { address };
   session.respondentSolicitorReferenceDataId = get(respondentSolicitorOrganisation, 'organisationIdentifier');
   session.respondentSolicitorReference = get(body, 'respondentSolicitorReference');
+};
+
+const mapRespondentSolicitorCyaData = session => {
+  const displayContentList = [].concat(
+    get(session, 'respondentSolicitorName'),
+    get(session, 'respondentSolicitorCompany'),
+    get(session, 'respondentSolicitorAddress.address'),
+    get(session, 'respondentSolicitorEmail'),
+    get(session, 'respondentSolicitorReference')
+  );
+
+  return trimAndRemoveBlanks(displayContentList).join('<br>');
 };
 
 const errorsCleanup = session => {
@@ -247,7 +263,6 @@ module.exports = {
   UserAction,
   validateSearchRequest,
   fetchAndAddOrganisations,
-  mapValidationErrors,
   hasBeenPostedWithoutSubmitButton,
   isInValidManualData,
   isInValidSearchData,
@@ -256,8 +271,11 @@ module.exports = {
   errorsManualCleanup,
   parseManualAddress,
   parseAddressToManualAddress,
+  mapValidationErrors,
   mapRespondentSolicitorData,
+  mapRespondentSolicitorCyaData,
   cleanupBeforeSubmit,
   resetManualRespondentSolicitorData,
-  resetRespondentSolicitorData
+  resetRespondentSolicitorData,
+  trimAndRemoveBlanks
 };

--- a/app/core/utils/respondentSolicitorSearchHelper.test.js
+++ b/app/core/utils/respondentSolicitorSearchHelper.test.js
@@ -284,113 +284,181 @@ describe(modulePath, () => {
         expect(session.respondentSolicitorAddressManual).to.be.undefined;
       });
     });
-  });
 
-  describe('mapRespondentSolicitorData() - Digital', () => {
-    let session = {};
-    const buildRespondentSolicitorSessionData = () => {
-      return {
-        divorceWho: 'wife',
-        respondentSolicitorName: null,
-        respondentSolicitorEmail: null,
-        respondentSolicitorReference: null,
-        respondentSolicitorOrganisation: {
-          contactInformation: [
-            {
-              addressLine1: '19/22 Union St',
-              addressLine2: 'Oldham',
-              addressLine3: '',
-              country: 'United Kingdom',
-              county: 'Greater Manchester',
-              postCode: 'OL1 222',
-              townCity: 'Manchester'
-            }
-          ],
-          name: TEST_RESP_SOLICITOR_COMPANY,
-          organisationIdentifier: TEST_RESP_SOLICITOR_ID
-        },
-        respondentSolicitorFirm: 'searchCriteria'
-      };
-    };
-
-    beforeEach(() => {
-      session = buildRespondentSolicitorSessionData();
-      req = { session };
-    });
-
-    afterEach(() => {
-      session = {};
-    });
-
-    it('should map current data to expected respondent solicitor payload', () => {
-      const expectedAddress = [
-        '19/22 Union St',
-        'Oldham',
-        'United Kingdom',
-        'Greater Manchester',
-        'OL1 222',
-        'Manchester'
-      ];
-
-      req.body = {
-        respondentSolicitorName: TEST_RESP_SOLICITOR_NAME,
-        respondentSolicitorEmail: TEST_RESP_SOLICITOR_EMAIL,
-        respondentSolicitorReference: TEST_RESP_SOLICITOR_REF
-      };
-
-      underTest.mapRespondentSolicitorData(req);
-
-      expect(req.session.respondentSolicitorName).to.equal(TEST_RESP_SOLICITOR_NAME);
-      expect(req.session.respondentSolicitorEmail).to.equal(TEST_RESP_SOLICITOR_EMAIL);
-      expect(req.session.respondentSolicitorReference).to.equal(TEST_RESP_SOLICITOR_REF);
-      expect(req.session.respondentSolicitorCompany).to.equal(TEST_RESP_SOLICITOR_COMPANY);
-      expect(req.session.respondentSolicitorAddress).to.have.property('address');
-      expect(req.session.respondentSolicitorAddress.address).to.have.deep.members(expectedAddress);
-      expect(req.session.respondentSolicitorReferenceDataId).to.equal(TEST_RESP_SOLICITOR_ID);
-    });
-
-    it('should map empty array to solicitor address when no solicitor organisation', () => {
-      req.session.respondentSolicitorOrganisation = null;
-
-      underTest.mapRespondentSolicitorData(req);
-
-      expect(req.session.respondentSolicitorName).to.be.undefined;
-      expect(req.session.respondentSolicitorEmail).to.be.undefined;
-      expect(req.session.respondentSolicitorReference).to.be.undefined;
-      expect(req.session.respondentSolicitorCompany).to.be.undefined;
-      expect(req.session.respondentSolicitorAddress).to.have.property('address');
-      expect(req.session.respondentSolicitorAddress.address).to.have.lengthOf(0);
-      expect(req.session.respondentSolicitorReferenceDataId).to.be.undefined;
+    describe('trimAndRemoveBlanks()', () => {
+      const expectedLines = 5;
+      it('should correctly process list of items', () => {
+        const itemsArray = ['Some', ' ', 'items', null, 'in', 'a', 'list', ''];
+        const expectedResult = ['Some', 'items', 'in', 'a', 'list'];
+        const result = underTest.trimAndRemoveBlanks(itemsArray);
+        expect(result).to.deep.equal(expectedResult);
+        expect(result).to.have.lengthOf(expectedLines);
+      });
     });
   });
 
-  describe('mapRespondentSolicitorData() - Manual', () => {
-    const manualAddress = 'An\n\raddress\nline\n \r\nlast line';
-    const expectedAddress = ['An', 'address', 'line', 'last line'];
-
-    it('should map current data to expected respondent solicitor payload', () => {
-      req = {
-        body: {
-          respondentSolicitorNameManual: TEST_RESP_SOLICITOR_NAME,
-          respondentSolicitorEmailManual: TEST_RESP_SOLICITOR_EMAIL,
-          respondentSolicitorReference: TEST_RESP_SOLICITOR_REF,
-          respondentSolicitorAddressManual: manualAddress,
-          respondentSolicitorCompany: TEST_RESP_SOLICITOR_COMPANY
-        },
-        session: {
-          divorceWho: 'wife'
-        }
+  context('Session data mapping', () => {
+    describe('mapRespondentSolicitorData() - Digital', () => {
+      let session = {};
+      const buildRespondentSolicitorSessionData = () => {
+        return {
+          divorceWho: 'wife',
+          respondentSolicitorName: null,
+          respondentSolicitorEmail: null,
+          respondentSolicitorReference: null,
+          respondentSolicitorOrganisation: {
+            contactInformation: [
+              {
+                addressLine1: '19/22 Union St',
+                addressLine2: 'Oldham',
+                addressLine3: '',
+                country: 'United Kingdom',
+                county: 'Greater Manchester',
+                postCode: 'OL1 222',
+                townCity: 'Manchester'
+              }
+            ],
+            name: TEST_RESP_SOLICITOR_COMPANY,
+            organisationIdentifier: TEST_RESP_SOLICITOR_ID
+          },
+          respondentSolicitorFirm: 'searchCriteria'
+        };
       };
 
-      underTest.mapRespondentSolicitorData(req, true);
+      beforeEach(() => {
+        session = buildRespondentSolicitorSessionData();
+        req = { session };
+      });
 
-      expect(req.session.respondentSolicitorName).to.equal(TEST_RESP_SOLICITOR_NAME);
-      expect(req.session.respondentSolicitorEmail).to.equal(TEST_RESP_SOLICITOR_EMAIL);
-      expect(req.session.respondentSolicitorReference).to.equal(TEST_RESP_SOLICITOR_REF);
-      expect(req.session.respondentSolicitorCompany).to.equal(TEST_RESP_SOLICITOR_COMPANY);
-      expect(req.session.respondentSolicitorAddress).to.have.property('address');
-      expect(req.session.respondentSolicitorAddress.address).to.have.deep.members(expectedAddress);
-      expect(req.session.respondentSolicitorAddressManual).to.equal(manualAddress);
+      afterEach(() => {
+        session = {};
+      });
+
+      it('should map current data to expected respondent solicitor payload', () => {
+        const expectedAddress = [
+          '19/22 Union St',
+          'Oldham',
+          'United Kingdom',
+          'Greater Manchester',
+          'OL1 222',
+          'Manchester'
+        ];
+
+        req.body = {
+          respondentSolicitorName: TEST_RESP_SOLICITOR_NAME,
+          respondentSolicitorEmail: TEST_RESP_SOLICITOR_EMAIL,
+          respondentSolicitorReference: TEST_RESP_SOLICITOR_REF
+        };
+
+        underTest.mapRespondentSolicitorData(req);
+
+        expect(req.session.respondentSolicitorName).to.equal(TEST_RESP_SOLICITOR_NAME);
+        expect(req.session.respondentSolicitorEmail).to.equal(TEST_RESP_SOLICITOR_EMAIL);
+        expect(req.session.respondentSolicitorReference).to.equal(TEST_RESP_SOLICITOR_REF);
+        expect(req.session.respondentSolicitorCompany).to.equal(TEST_RESP_SOLICITOR_COMPANY);
+        expect(req.session.respondentSolicitorAddress).to.have.property('address');
+        expect(req.session.respondentSolicitorAddress.address).to.have.deep.members(expectedAddress);
+        expect(req.session.respondentSolicitorReferenceDataId).to.equal(TEST_RESP_SOLICITOR_ID);
+      });
+
+      it('should map empty array to solicitor address when no solicitor organisation', () => {
+        req.session.respondentSolicitorOrganisation = null;
+
+        underTest.mapRespondentSolicitorData(req);
+
+        expect(req.session.respondentSolicitorName).to.be.undefined;
+        expect(req.session.respondentSolicitorEmail).to.be.undefined;
+        expect(req.session.respondentSolicitorReference).to.be.undefined;
+        expect(req.session.respondentSolicitorCompany).to.be.undefined;
+        expect(req.session.respondentSolicitorAddress).to.have.property('address');
+        expect(req.session.respondentSolicitorAddress.address).to.have.lengthOf(0);
+        expect(req.session.respondentSolicitorReferenceDataId).to.be.undefined;
+      });
+    });
+
+    describe('mapRespondentSolicitorData() - Manual', () => {
+      const manualAddress = 'An\n\raddress\nline\n \r\nlast line';
+      const expectedAddress = ['An', 'address', 'line', 'last line'];
+
+      it('should map current data to expected respondent solicitor payload', () => {
+        req = {
+          body: {
+            respondentSolicitorNameManual: TEST_RESP_SOLICITOR_NAME,
+            respondentSolicitorEmailManual: TEST_RESP_SOLICITOR_EMAIL,
+            respondentSolicitorReference: TEST_RESP_SOLICITOR_REF,
+            respondentSolicitorAddressManual: manualAddress,
+            respondentSolicitorCompany: TEST_RESP_SOLICITOR_COMPANY
+          },
+          session: {
+            divorceWho: 'wife'
+          }
+        };
+
+        underTest.mapRespondentSolicitorData(req, true);
+
+        expect(req.session.respondentSolicitorName).to.equal(TEST_RESP_SOLICITOR_NAME);
+        expect(req.session.respondentSolicitorEmail).to.equal(TEST_RESP_SOLICITOR_EMAIL);
+        expect(req.session.respondentSolicitorReference).to.equal(TEST_RESP_SOLICITOR_REF);
+        expect(req.session.respondentSolicitorCompany).to.equal(TEST_RESP_SOLICITOR_COMPANY);
+        expect(req.session.respondentSolicitorAddress).to.have.property('address');
+        expect(req.session.respondentSolicitorAddress.address).to.have.deep.members(expectedAddress);
+        expect(req.session.respondentSolicitorAddressManual).to.equal(manualAddress);
+      });
+    });
+
+    describe('mapRespondentSolicitorCyaData', () => {
+      it('should correctly generate CYA content when all data is available', () => {
+        req.session = {
+          respondentSolicitorName: TEST_RESP_SOLICITOR_NAME,
+          respondentSolicitorCompany: TEST_RESP_SOLICITOR_COMPANY,
+          respondentSolicitorAddress: {
+            address: [
+              'address line 1',
+              '',
+              'address line 3'
+            ]
+          },
+          respondentSolicitorEmail: TEST_RESP_SOLICITOR_EMAIL,
+          respondentSolicitorReference: TEST_RESP_SOLICITOR_REF
+        };
+        const expectedCyaContent = [
+          TEST_RESP_SOLICITOR_NAME,
+          TEST_RESP_SOLICITOR_COMPANY,
+          'address line 1',
+          'address line 3',
+          TEST_RESP_SOLICITOR_EMAIL,
+          TEST_RESP_SOLICITOR_REF
+        ].join('<br>');
+
+        const cyaContent = underTest.mapRespondentSolicitorCyaData(req.session);
+
+        expect(cyaContent).to.deep.equal(expectedCyaContent);
+      });
+
+      it('should correctly generate CYA content when some optional data not available', () => {
+        req.session = {
+          respondentSolicitorName: TEST_RESP_SOLICITOR_NAME,
+          respondentSolicitorCompany: TEST_RESP_SOLICITOR_COMPANY,
+          respondentSolicitorAddress: {
+            address: [
+              'address line 1',
+              'address line 2'
+            ]
+          },
+          respondentSolicitorEmail: TEST_RESP_SOLICITOR_EMAIL
+        };
+        const expectedCyaContent = [
+          TEST_RESP_SOLICITOR_NAME,
+          TEST_RESP_SOLICITOR_COMPANY,
+          'address line 1',
+          'address line 2',
+          TEST_RESP_SOLICITOR_EMAIL
+        ].join('<br>');
+
+        const cyaContent = underTest.mapRespondentSolicitorCyaData(req.session);
+
+        expect(cyaContent).to.deep.equal(expectedCyaContent);
+      });
     });
   });
 

--- a/app/steps/respondent/correspondence/solicitor-search/index.js
+++ b/app/steps/respondent/correspondence/solicitor-search/index.js
@@ -112,8 +112,7 @@ module.exports = class RespondentCorrespondenceSolicitorSearch extends Validatio
 
   checkYourAnswersInterceptor(ctx, session) {
     if (session.respondentSolicitorAddress) {
-      const solicitorDetail = [].concat(session.respondentSolicitorName, session.respondentSolicitorAddress.address);
-      ctx.cyaRespondentSolicitorAddress = solicitorDetail.join('<br>');
+      ctx.respondentSolicitorDisplayAddress = searchHelper.mapRespondentSolicitorCyaData(session);
     }
     return ctx;
   }

--- a/app/steps/respondent/correspondence/solicitor-search/index.test.js
+++ b/app/steps/respondent/correspondence/solicitor-search/index.test.js
@@ -259,18 +259,29 @@ describe(modulePath, () => {
           session = {};
         });
 
-        it('renders the cya template', done => {
+        it('should render the cya template', done => {
           testCYATemplate(done, underTest, {}, session);
         });
 
-        it('renders address', done => {
-          testExistenceCYA(done, underTest, content, [], [], {}, {
+        it('should renders address solicitor address', done => {
+          const contentToExist = ['question'];
+          const valuesToExist = [
+            'divorceWho',
+            'respondentSolicitorDisplayAddress'
+          ];
+          const context = {
+            respondentSolicitorDisplayAddress: 'Solicitor name<br>line 1<br>line 2<br>line 3<br>email@email.com'
+          };
+          session = {
             divorceWho: 'wife',
             respondentSolicitorName: 'Solicitor name',
+            respondentSolicitorEmail: 'email@email.com',
             respondentSolicitorAddress: {
-              address: ['line 1', 'line 2', 'line 3', 'postcode']
+              address: ['line 1', 'line 2', 'line 3']
             }
-          });
+          };
+
+          testExistenceCYA(done, underTest, content, contentToExist, valuesToExist, context, session);
         });
       });
     });

--- a/app/steps/respondent/correspondence/solicitor-search/partials/checkYourAnswersTemplate.html
+++ b/app/steps/respondent/correspondence/solicitor-search/partials/checkYourAnswersTemplate.html
@@ -3,9 +3,7 @@
     {{ content.question | safe }}
   </td>
   <td class="govuk-table__cell">
-    {% if session.respondentSolicitorAddress %}
-    <span class="address">{{ fields.cyaRespondentSolicitorAddress.value | safe }}</span>
-    {% endif %}
+    <span class="address">{{ fields.respondentSolicitorDisplayAddress.value | safe }}</span>
   </td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><a class="govuk-link" aria-label="{{ content.change }} {{ content.question | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>
 </tr>

--- a/app/steps/respondent/correspondence/use-home-address/index.js
+++ b/app/steps/respondent/correspondence/use-home-address/index.js
@@ -5,6 +5,7 @@ module.exports = class RespondentCorrespondenceUseHomeAddress extends Validation
   get url() {
     return '/petitioner-respondent/respondent-correspondence/use-home-address';
   }
+
   get nextStep() {
     return {
       respondentCorrespondenceUseHomeAddress: {
@@ -35,6 +36,18 @@ module.exports = class RespondentCorrespondenceUseHomeAddress extends Validation
     ctx.isRespSolToggleOn = session.featureToggles.ft_represented_respondent_journey;
   }
 
+  setRespondentCorrespondenceDisplayAnswer(ctx, session) {
+    if (ctx.isRespSolToggleOn === true) {
+      if (ctx.respondentCorrespondenceUseHomeAddress === 'Yes') {
+        ctx.respondentCorrespondenceWherePaperSent = this.getDestinationResponse(session, 'theirAddress');
+      } else if (ctx.respondentCorrespondenceUseHomeAddress === 'No') {
+        ctx.respondentCorrespondenceWherePaperSent = this.getDestinationResponse(session, 'anotherAddress');
+      } else if (ctx.respondentCorrespondenceUseHomeAddress === 'Solicitor') {
+        ctx.respondentCorrespondenceWherePaperSent = this.getDestinationResponse(session, 'solicitorAddress');
+      }
+    }
+  }
+
   setRespondentCorrespondenceDisplayAddress(ctx, session) {
     ctx.respondentCorrespondenceDisplayAddress = '';
 
@@ -50,7 +63,8 @@ module.exports = class RespondentCorrespondenceUseHomeAddress extends Validation
 
   interceptor(ctx, session) {
     this.setRespSolToggle(ctx, session);
-    return this.setRespondentCorrespondenceDisplayAddress(ctx, session);
+    this.setRespondentCorrespondenceDisplayAddress(ctx, session);
+    return ctx;
   }
 
   action(ctx, session) {
@@ -60,11 +74,18 @@ module.exports = class RespondentCorrespondenceUseHomeAddress extends Validation
     // remove data used for template
     delete session.respondentCorrespondenceDisplayAddress;
     delete ctx.respondentCorrespondenceDisplayAddress;
+    delete ctx.respondentCorrespondenceWherePaperSent;
 
     return [ctx, session];
   }
 
+  getDestinationResponse(session, option) {
+    return this.content.resources[session.language].translation.content.featureToggleRespSol[option];
+  }
+
   checkYourAnswersInterceptor(ctx, session) {
-    return this.setRespondentCorrespondenceDisplayAddress(ctx, session);
+    this.setRespondentCorrespondenceDisplayAnswer(ctx, session);
+    this.setRespondentCorrespondenceDisplayAddress(ctx, session);
+    return ctx;
   }
 };

--- a/app/steps/respondent/correspondence/use-home-address/index.js
+++ b/app/steps/respondent/correspondence/use-home-address/index.js
@@ -42,7 +42,7 @@ module.exports = class RespondentCorrespondenceUseHomeAddress extends Validation
         ctx.respondentCorrespondenceWherePaperSent = this.getDestinationResponse(session, 'theirAddress');
       } else if (ctx.respondentCorrespondenceUseHomeAddress === 'No') {
         ctx.respondentCorrespondenceWherePaperSent = this.getDestinationResponse(session, 'anotherAddress');
-      } else if (ctx.respondentCorrespondenceUseHomeAddress === 'Solicitor') {
+      } else {
         ctx.respondentCorrespondenceWherePaperSent = this.getDestinationResponse(session, 'solicitorAddress');
       }
     }

--- a/app/steps/respondent/correspondence/use-home-address/index.test.js
+++ b/app/steps/respondent/correspondence/use-home-address/index.test.js
@@ -110,7 +110,6 @@ describe(modulePath, () => {
     });
   });
 
-
   describe('when respondent lives at same address', () => {
     let session = {};
 
@@ -183,6 +182,14 @@ describe(modulePath, () => {
       const newSession = removeStaleData(previousSession, session);
       expect(typeof newSession.respondentCorrespondenceAddress)
         .to.equal('undefined');
+    });
+  });
+
+  describe('Where papers are sent', () => {
+    it('should set the value to \'theirAddress\'', () => {
+      const ctx = { isRespSolToggleOn: true };
+      const session = { language: 'en' };
+      underTest.setRespondentCorrespondenceDisplayAnswer(ctx, session);
     });
   });
 

--- a/app/steps/respondent/correspondence/use-home-address/index.test.js
+++ b/app/steps/respondent/correspondence/use-home-address/index.test.js
@@ -186,11 +186,28 @@ describe(modulePath, () => {
   });
 
   describe('Where papers are sent', () => {
-    it('should set the value to \'theirAddress\'', () => {
-      const ctx = { isRespSolToggleOn: true };
-      const session = { language: 'en' };
-      underTest.setRespondentCorrespondenceDisplayAnswer(ctx, session);
-    });
+    const getSolicitorContent = (session, option) => {
+      return content.resources[session.language].translation.content.featureToggleRespSol[option];
+    };
+
+    forEach([
+      ['Yes', 'theirAddress'],
+      ['No', 'anotherAddress'],
+      ['Solicitor', 'solicitorAddress']
+    ])
+      .it('should set the correct value when users option is %s', (useHomeAddress, contentOption) => {
+        const ctx = {
+          isRespSolToggleOn: true,
+          respondentCorrespondenceUseHomeAddress: useHomeAddress
+        };
+        const session = { language: 'en' };
+
+        underTest.setRespondentCorrespondenceDisplayAnswer(ctx, session);
+
+        // eslint-disable-next-line no-unused-expressions
+        expect(ctx.respondentCorrespondenceWherePaperSent).not.to.be.undefined;
+        expect(ctx.respondentCorrespondenceWherePaperSent).to.equal(getSolicitorContent(session, contentOption));
+      });
   });
 
   context('Check Your Answers', () => {

--- a/app/steps/respondent/correspondence/use-home-address/partials/checkYourAnswersTemplate.html
+++ b/app/steps/respondent/correspondence/use-home-address/partials/checkYourAnswersTemplate.html
@@ -1,11 +1,19 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell">
-    {{ content.question | safe }}
+    {% if fields.isRespSolToggleOn.value === true %}
+      {{ content.featureToggleRespSol.question | safe }}
+    {% else %}
+      {{ content.question | safe }}
+    {% endif %}
   </td>
   <td class="govuk-table__cell">
-    {{ content[fields.respondentCorrespondenceUseHomeAddress.value | lower]| safe }}
-    {% if fields.respondentCorrespondenceDisplayAddress.value %}
-      <span class="address">{{ fields.respondentCorrespondenceDisplayAddress.value.address | join("<br/>") | safe }}</span>
+    {% if fields.isRespSolToggleOn.value === true %}
+      {{ fields.respondentCorrespondenceWherePaperSent.value | safe }}
+    {% else %}
+      {{ content[fields.respondentCorrespondenceUseHomeAddress.value | lower]| safe }}
+      {% if fields.respondentCorrespondenceDisplayAddress.value %}
+        <span class="address">{{ fields.respondentCorrespondenceDisplayAddress.value.address | join("<br/>") | safe }}</span>
+      {% endif %}
     {% endif %}
   </td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><a class="govuk-link" aria-label="{{ content.change }} {{ content.question | safe }}" href="{{ content.url | safe }}">{{ content.change }}</a></td>


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-6837

CYA views for both Use Home Address and Solicitor Search have been updated to reflect the current updates introduced by the Respondent Solicitor Search feature. Correct data is now displayed for the `Where should your <xxx> divorce papers be sent?` and `Enter details of your <xxx> solicitor`. All updates to the Use home address CYA display view is behind a feature toggle as well.

![Screenshot 2021-03-23 at 11 32 23](https://user-images.githubusercontent.com/11870499/112142873-072fdb00-8bcf-11eb-88a0-ae80ebbb7c27.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
