### PR TITLE
Remove attempt to parameterise cookie domian

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,21 +1,13 @@
 const webpack = require('webpack');
 const webpackConfig = require('./webpack.config.js');
 const ArchivePlugin = require('webpack-archive-plugin');
-const CONF = require("config");
-
 
 module.exports = function(grunt) {
   grunt.initConfig({
 
     webpack: {
       options: webpackConfig,
-      dev: {
-        devtool: 'sourcemap',
-        plugins: webpackConfig.plugins.concat(
-          // Replace variable values of COOKIEDOMAIN in JS files with the value of CONF.cookieDomain (as a quoted str)
-          new webpack.DefinePlugin({ 'COOKIEDOMAIN': JSON.stringify(CONF.cookieDomain) }),
-        )
-      },
+      dev: { devtool: 'sourcemap' },
       assets: {
         plugins: webpackConfig.plugins.concat(
           new ArchivePlugin({ output: 'dist', format: 'tar' })
@@ -23,9 +15,7 @@ module.exports = function(grunt) {
       },
       prod: {
         plugins: webpackConfig.plugins.concat(
-          new webpack.DefinePlugin({ 'process.env': { NODE_ENV: 'production' } }),
-          // Replace variable values of COOKIEDOMAIN in JS files with the value of CONF.cookieDomain (as a quoted str)
-          new webpack.DefinePlugin({ 'COOKIEDOMAIN': JSON.stringify(CONF.cookieDomain) })
+          new webpack.DefinePlugin({ 'process.env': { NODE_ENV: 'production' } })
         )
       }
     },

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,16 +31,6 @@ window.jQuery = $;
 
     govukFrontend.initAll();
 
-    // COOKIEDOMAIN is populated by WebPack config
-    // eslint-disable-next-line no-undef
-    const cookieDomain = COOKIEDOMAIN;
-    // eslint-disable-next-line no-console
-    console.log(`
-
-              ==========================================================================================
-                Cookie Domain: ${cookieDomain}
-              ==========================================================================================
-    `);
   });
 
 })(window);

--- a/app/assets/javascripts/cookiesManager.js
+++ b/app/assets/javascripts/cookiesManager.js
@@ -95,10 +95,7 @@ function setCookie(cname, cvalue, exdays) {
   // eslint-disable-next-line no-magic-numbers
   d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
   const expires = `expires=${d.toUTCString()}`;
-  // COOKIEDOMAIN is populated by WebPack config
-  // eslint-disable-next-line no-undef
-  const cookieDomain = COOKIEDOMAIN;
-  document.cookie = `${cname}=${cvalue};${expires};path=/;domain=${cookieDomain};Secure=true`;
+  document.cookie = `${cname}=${cvalue};${expires};path=/;domain=aat.platform.hmcts.net;Secure=true`;
 }
 
 function getCookie(cname) {

--- a/charts/div-pfe/values.demo.template.yaml
+++ b/charts/div-pfe/values.demo.template.yaml
@@ -5,4 +5,3 @@ nodejs:
     environment:
       ANTENNA_WEBCHAT_URL: "webchat-client.training.ctsc.hmcts.net"
       ANTENNA_WEBCHAT_SERVICE: "Testing"
-      COOKIE_DOMAIN: "demo.platform.hmcts.net"

--- a/charts/div-pfe/values.preview.template.yaml
+++ b/charts/div-pfe/values.preview.template.yaml
@@ -21,7 +21,6 @@ nodejs:
         FEATURE_DYNATRACE: "false"
         DECREE_NISI_FRONTEND_URL: "https://decree-nisi-aks.aat.platform.hmcts.net"
 
-
     keyVaults:
         div:
             secrets:

--- a/charts/div-pfe/values.yaml
+++ b/charts/div-pfe/values.yaml
@@ -69,11 +69,6 @@ nodejs:
 
         FEATURE_DYNATRACE: "false"
 
-        # Leave AAT as default for now, until we have a release window to change in prod, then switch prod to default
-        # COOKIE_DOMAIN: "apply-divorce.service.gov.uk"
-        COOKIE_DOMAIN: "Test.Cookie.Domain.Value.Values"
-
-
     keyVaults:
         div:
             secrets:

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -90,8 +90,6 @@ features:
   newFees: FEATURE_NEW_FEES
   dynatrace: FEATURE_DYNATRACE
 
-cookieDomain: COOKIE_DOMAIN
-
 idamArgs:
   idamApiUrl: IDAM_API_URL
   idamLoginUrl: IDAM_LOGIN_URL

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -75,8 +75,6 @@ paymentDateFormat: 'DDMMYYYY'
 
 testUrl: 'https://localhost:3000'
 
-cookieDomain: "Test.Cookie.Domain.Value.Default"
-
 commonProps:
   applicationFee:
     feeCode: 'FEE0002'
@@ -110,7 +108,7 @@ features:
   strategicPay: false
   antennaWebchatUserAttribute: false
   newFees: true
-  dynatrace: true
+  dynatrace: false
 
 idamArgs:
   redirectUri: 'https://localhost:3000/authenticated'

--- a/server.js
+++ b/server.js
@@ -9,15 +9,6 @@ if (CONF.environment !== 'testing') {
 
 const listenForConnections = true;
 
-const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
-
-logger.info(`
-
-              ==========================================================================================
-                Cookie Domain: ${CONF.cookieDomain}
-              ==========================================================================================
-`);
-
 if (CONF.applicationInsights.instrumentationKey) {
   appInsights.setup(CONF.applicationInsights.instrumentationKey)
     .setAutoCollectConsole(true, true)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 'use strict';
-const CONF = require('config');
 const fs = require('fs');
 const path = require('path');
 
@@ -45,10 +44,6 @@ module.exports = {
     new CopyWebpackPlugin([
       { from: './tmp/images', to: 'images' }
     ]),
-    // new webpack.DefinePlugin({
-      // Replace variable values of COOKIEDOMAIN in JS files with the value of CONF.cookieDomain (as a quoted str)
-      // 'COOKIEDOMAIN': JSON.stringify(CONF.cookieDomain)
-    // }),
     extractSass,
     function() {
       this.plugin('done', stats => {


### PR DESCRIPTION
Roll back attempt to parameterise cookie domain.

Lack of differentiation between AAT and Prod at the build stage prevents this approach from being viable.